### PR TITLE
(MODULES-6323) EmbeddedInstance support

### DIFF
--- a/lib/puppet/provider/base_dsc_lite/invoke_generic_dsc_resource.ps1.erb
+++ b/lib/puppet/provider/base_dsc_lite/invoke_generic_dsc_resource.ps1.erb
@@ -1,8 +1,7 @@
 $script:ErrorActionPreference = 'Stop'
 $script:WarningPreference     = 'SilentlyContinue'
 
-function new-pscredential
-{
+function new-pscredential{
   [CmdletBinding()]
   param (
     [parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
@@ -39,12 +38,12 @@ try{
 }
 
 # keep the switch for when Test passes back changed properties
-switch ($invokeParams.Method) {
-  'Test' {
+switch($invokeParams.Method){
+  'Test'{
     $response.indesiredstate = $result.InDesiredState
     return ($response | ConvertTo-Json -Compress)
   }
-  'Set' {
+  'Set'{
     $response.indesiredstate = $true
     $response.rebootrequired = $result.RebootRequired
     return ($response | ConvertTo-Json -Compress)

--- a/lib/puppet/type/dsc.rb
+++ b/lib/puppet/type/dsc.rb
@@ -44,7 +44,11 @@ Puppet::Type.newtype(:dsc) do
   end
 
   newparam(:dsc_resource_properties, :array_matching => :all) do
-    desc "DSC Resource Properties"
+    desc <<-HERE
+    The hash of properties to pass to the DSC Resource.
+
+    To express EmbeddedInstances, the dsc_resource_properties parameter will reconize any key with a hash value that contains two keys: dsc_type and dsc_properties, as a indication of how to format the data supplied. The dsc_type contains the CimInstance name to use, and the dsc_properties contains a hash or an array of hashes representing the data for the CimInstances. If the CimInstance is an array, we append a [] to the end of the name.
+HERE
     isrequired
     validate do |value|
       if value.nil? or value.empty?

--- a/spec/integration/puppet_x/puppetlabs/powershell_hash_formatter_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_hash_formatter_spec.rb
@@ -13,44 +13,189 @@ describe PuppetX::PuppetLabs::DscLite::PowerShellHashFormatter do
     describe "when given correct hash" do
 
       it "should output correct syntax with simple example" do
-        foo = <<-HERE
+        expected = <<-HERE
 @{
 'ensure' = 'present';
 'name' = 'Web-WebServer'
 }
 HERE
         result = @formatter.format({
-            "ensure"      => "present",
-            "name"      => "Web-WebServer",
+            "ensure" => "present",
+            "name"   => "Web-WebServer",
         })
-        expect(result).to eq foo.strip
+        expect(result).to eq expected.strip
       end
 
-      it "should output correct syntax with CimInstance" do
-        foo = <<-HERE
+      it "should output correct syntax with single CimInstance for a CimInstance[] type" do
+        expected = <<-HERE
 @{
 'ensure' = 'Present';
-'bindinginfo' = @{
-'dsc_type' = 'MSFT_xWebBindingInformation[]';
-'dsc_properties' = @{
+'name' = 'foo';
+'state' = 'Started';
+'physicalpath' = 'c:/inetpub/wwwroot';
+'bindinginfo' = [CimInstance[]]@(
+(New-CimInstance -ClassName 'MSFT_xWebBindingInformation' -ClientOnly -Property @{
 'protocol' = 'HTTP';
-'port' = '80'
-}
-}
+'port' = 80
+})
+)
 }
 HERE
+
         result = @formatter.format({
           "ensure"      => "Present",
+          'name'            => "foo",
+          'state'           => "Started",
+          'physicalpath'    => "c:/inetpub/wwwroot",
           "bindinginfo" => {
             "dsc_type"       => "MSFT_xWebBindingInformation[]",
             "dsc_properties" => {
               "protocol" => "HTTP",
-              "port"     => "80"
+              "port"     => 80
             }
           }
         })
-        expect(result).to eq foo.strip
+
+        expect(result).to eq expected.strip
       end
+
+      it "should output correct syntax with single CimInstance for a CimInstance type" do
+        expected = <<-HERE
+@{
+'ensure' = 'Present';
+'name' = 'foo';
+'state' = 'Started';
+'physicalpath' = 'c:/inetpub/wwwroot';
+'authenticationinfo' = [CimInstance](New-CimInstance -ClassName 'MSFT_xWebAuthenticationInformation' -ClientOnly -Property @{
+'anonymous' = $true;
+'basic' = $false;
+'windows' = $true;
+'digest' = $false
+})
+}
+HERE
+
+        result = @formatter.format({
+          "ensure"      => "Present",
+          'name'            => "foo",
+          'state'           => "Started",
+          'physicalpath'    => "c:/inetpub/wwwroot",
+          "authenticationinfo" => {
+            "dsc_type"       => "MSFT_xWebAuthenticationInformation",
+            "dsc_properties" => {
+                'anonymous' => true,
+                'basic' => false,
+                'windows' => true,
+                'digest' => false,
+            }
+          }
+        })
+
+        expect(result).to eq expected.strip
+      end
+
+      it "should output correct syntax with array CimInstance" do
+        expected = <<-HERE
+@{
+'ensure' = 'Present';
+'name' = 'foo';
+'state' = 'Started';
+'physicalpath' = 'c:/inetpub/wwwroot';
+'bindinginfo' = [CimInstance[]]@(
+(New-CimInstance -ClassName 'MSFT_xWebBindingInformation' -ClientOnly -Property @{
+'protocol' = 'HTTP';
+'port' = 80
+}),
+(New-CimInstance -ClassName 'MSFT_xWebBindingInformation' -ClientOnly -Property @{
+'protocol' = 'HTTPS';
+'port' = 443;
+'certificatethumbprint' = '5438DC0CB31B1C91B8945C7D91B3338F9C08BEFA';
+'certificatestorename' = 'My';
+'ipaddress' = '*'
+})
+)
+}
+HERE
+
+        result = @formatter.format({
+          "ensure"       => "Present",
+          'name'         => "foo",
+          'state'        => "Started",
+          'physicalpath' => "c:/inetpub/wwwroot",
+          'bindinginfo'  => {
+            "dsc_type"       => "MSFT_xWebBindingInformation[]",
+            "dsc_properties" => [
+              {
+                "protocol" => "HTTP",
+                "port"     => 80
+              },
+              {
+                'protocol'             => 'HTTPS',
+                'port'                 => 443,
+                'certificatethumbprint' => '5438DC0CB31B1C91B8945C7D91B3338F9C08BEFA',
+                'certificatestorename'  => 'My',
+                'ipaddress'            => '*'
+              }
+            ]
+          }
+        })
+
+        expect(result).to eq expected.strip
+      end
+
+      it "should output correct syntax with a PSCredential" do
+        expected = <<-HERE
+@{
+'username' = 'jane-doe';
+'description' = 'Jane Doe user';
+'ensure' = 'present';
+'password' = ([PSCustomObject]@{
+'user' = 'jane-doe';
+'password' = 'jane-password'
+} | new-pscredential);
+'passwordneverexpires' = $false;
+'disabled' = $true
+}
+HERE
+        result = @formatter.format({
+          'username'    => 'jane-doe',
+          'description' => 'Jane Doe user',
+          'ensure'      => 'present',
+          'password'    => {
+            'dsc_type' => 'MSFT_Credential',
+            'dsc_properties' => {
+              'user'     => 'jane-doe',
+              'password' => 'jane-password'
+            }
+          },
+          'passwordneverexpires' => false,
+          'disabled'             => true,
+        })
+        expect(result).to eq expected.strip
+      end
+
+      it "should output correct syntax with MSFT_KeyValuePair" do
+        expected = <<-HERE
+@{
+'destinationPath' = 'c:\fileName.jpg';
+'uri' = 'http://www.contoso.com/image.jpg';
+'userAgent' = '[Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer';
+'headers' = @{
+'Accept-Language' = 'en-US'
+}
+}
+HERE
+        result = @formatter.format({
+          'destinationPath' => "c:\fileName.jpg",
+          'uri'             => "http://www.contoso.com/image.jpg",
+          'userAgent'       => "[Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer",
+          'headers'         => {
+            "Accept-Language" => "en-US"
+          }
+        })
+        expect(result).to eq expected.strip
+      end
+
     end
   end
 end


### PR DESCRIPTION
This commit adds support for EmbeddedInstances (complex types and CIM Instances) when using `Invoke-DscResource` with the generic dsc type.

This commit also updates the `Usage` section of the README to reflect the usage of the dsc type. It does not attempt to update the entire README to reflect the changes from the dsc module, as that is out of scope for this PR.
