### PR TITLE
(maint) Fix typo in readme title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dsc
+# dsc_lite
 
 [wmf-5.0]: https://www.microsoft.com/en-us/download/details.aspx?id=50395
 [DSCResources]: https://github.com/powershell/DSCResources


### PR DESCRIPTION
The README still has dsc as the title.  This commit changes the title to
dsc_lite.