### PR TITLE
Revert "(maint) Acceptance test minor cleanup"

### DIFF
--- a/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_before_puppet_type.rb
@@ -1,0 +1,56 @@
+require 'dsc_utils'
+require 'securerandom'
+
+test_name 'FM-2624 - C68527 - Apply DSC Resource Manifest with "before" on Puppet Resource Type'
+
+confine(:to, :platform => 'windows')
+
+# In-line Manifest
+test_file_name = SecureRandom.uuid
+test_file_path = "C:/#{test_file_name}"
+test_file_contents = SecureRandom.uuid
+fake_name = SecureRandom.uuid
+fake_file_contents = SecureRandom.uuid
+
+dsc_manifest = <<-MANIFEST
+file {'#{test_file_path}':
+  ensure  => 'file',
+  content => '#{test_file_contents}'
+}
+dsc_puppetfakeresource {'#{fake_name}':
+  dsc_ensure          => 'present',
+  dsc_importantstuff  => '#{fake_file_contents}',
+  before              => File['#{test_file_path}']
+}
+MANIFEST
+
+# Teardown
+teardown do
+  step 'Remove Test Artifacts and Type Wrappers'
+  on(agents, "rm -rf /cygdrive/c/#{test_file_name}")
+  agents.each do |agent|
+    uninstall_fake_reboot_resource(agent)
+  end
+end
+
+# Tests
+agents.each do |agent|
+  step 'Copy Test Type Wrappers'
+  install_fake_reboot_resource(agent)
+
+  step 'Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    assert_match(/Stage\[main\]\/Main\/Dsc_puppetfakeresource\[#{fake_name}\]\/ensure\: created/, result.stdout, 'DSC Resource missing!')
+  end
+
+  step 'Verify Results'
+  on(agent, "cat /cygdrive/c/#{test_file_name}", :acceptable_exit_codes => [0]) do |result|
+    assert_match(/#{test_file_contents}/, result.stdout, 'File contents incorrect!')
+  end
+
+  # PuppetFakeResource always overwrites file here with "importantstuff"
+  on(agent, "cat /cygdrive/c/fakeresource.txt", :acceptable_exit_codes => [0]) do |result|
+    assert_match(/#{fake_file_contents}/, result.stdout, 'PuppetFakeResource File contents incorrect!')
+  end
+end

--- a/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/dsc_require_puppet_type.rb
@@ -1,0 +1,51 @@
+require 'dsc_utils'
+require 'securerandom'
+
+test_name 'FM-2624 - C68526 - Apply DSC Resource Manifest with "requires" on Puppet Resource Type'
+
+confine(:to, :platform => 'windows')
+
+# In-line Manifest
+test_dir_path = SecureRandom.uuid
+fake_name = SecureRandom.uuid
+fake_file_contents = SecureRandom.uuid
+
+dsc_manifest = <<-MANIFEST
+dsc_puppetfakeresource {'#{fake_name}':
+  dsc_ensure          => 'present',
+  dsc_importantstuff  => '#{fake_file_contents}',
+  require             => File['C:/#{test_dir_path}']
+}
+file {'C:/#{test_dir_path}':
+  ensure => 'directory'
+}
+MANIFEST
+
+# Teardown
+teardown do
+  step 'Remove Test Artifacts'
+  on(agents, "rm -rf /cygdrive/c/#{test_dir_path}")
+  agents.each do |agent|
+    uninstall_fake_reboot_resource(agent)
+  end
+end
+
+# Tests
+agents.each do |agent|
+  step 'Copy Test Type Wrappers'
+  install_fake_reboot_resource(agent)
+
+  step 'Apply Manifest'
+  on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+    assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    assert_match(/Stage\[main\]\/Main\/Dsc_puppetfakeresource\[#{fake_name}\]\/ensure\: created/, result.stdout, 'DSC Resource missing!')
+  end
+
+  step 'Verify Results'
+  on(agent, "test -d \"/cygdrive/c/#{test_dir_path}\"", :acceptable_exit_codes => [0])
+
+  # PuppetFakeResource always overwrites file here with "importantstuff"
+  on(agent, "cat /cygdrive/c/fakeresource.txt", :acceptable_exit_codes => [0]) do |result|
+    assert_match(/#{fake_file_contents}/, result.stdout, 'PuppetFakeResource File contents incorrect!')
+  end
+end

--- a/tests/acceptance/tests/basic_functionality/alternate_path_separator.rb
+++ b/tests/acceptance/tests/basic_functionality/alternate_path_separator.rb
@@ -5,39 +5,24 @@ test_name 'FM-2623 - C68680 - Apply DSC Resource Manifest Containing Alternate P
 
 confine(:to, :platform => 'windows')
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # ERB Manifests
 test_dir_path = SecureRandom.uuid
 fake_name = SecureRandom.uuid
 
 test_file_path = "C:\\#{test_dir_path}\\#{fake_name}.txt"
 original_contents = SecureRandom.uuid
-
-dsc_manifest = <<-MANIFEST
-file { 'C:/<%= test_dir_path %>' :
-   ensure => 'directory'
-}
-->
-dsc_puppetfakeresource {'<%= fake_name %>':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => '<%= original_contents %>',
-  dsc_destinationpath => '<%= test_file_path %>',
-}
-MANIFEST
+test_file_contents = original_contents
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_functionality', 'test_file_path.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 
 # create another manifest, with new contents and reversed separators
+test_file_path = test_file_path.gsub("\\", '/')
 updated_contents = SecureRandom.uuid
-
-dsc_manifest2 = <<-MANIFEST
-file { 'C:/<%= test_dir_path %>' :
-   ensure => 'directory'
-}
-->
-dsc_puppetfakeresource {'<%= fake_name %>':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => '<%= updated_contents %>',
-  dsc_destinationpath => '<%= test_file_path.gsub("\\", "/") %>',
-}
-MANIFEST
+test_file_contents = updated_contents
+dsc_manifest2 = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 
 # Teardown
 teardown do

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_debug_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_debug_dsc_manifest.rb
@@ -5,21 +5,16 @@ test_name 'FM-2623 - C68534 - Apply DSC Resource Manifest via "puppet apply" wit
 
 confine(:to, :platform => 'windows')
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # ERB Manifest
 test_dir_path = SecureRandom.uuid
 fake_name = SecureRandom.uuid
+test_file_contents = SecureRandom.uuid
 
-dsc_manifest = <<-MANIFEST
-file { 'C:/<%= test_dir_path %>' :
-   ensure => 'directory'
-}
-->
-dsc_puppetfakeresource {'<%= fake_name %>':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => '<%= SecureRandom.uuid %>',
-  dsc_destinationpath => '<%= "C:\\" + test_dir_path + "\\" + fake_name %>',
-}
-MANIFEST
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_functionality', 'test_file_path.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 
 # Verify
 debug_msg = /Debug:.*Dsc_puppetfakeresource\[#{fake_name}\]: The container Class\[Main\] will propagate my refresh event/

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
@@ -5,22 +5,16 @@ test_name 'FM-2625 - C68511 - Apply DSC Resource Manifest via "puppet apply"'
 
 confine(:to, :platform => 'windows')
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # ERB Manifest
 test_dir_path = SecureRandom.uuid
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid
 
-dsc_manifest = <<-MANIFEST
-file { 'C:/<%= test_dir_path %>' :
-   ensure => 'directory'
-}
-->
-dsc_puppetfakeresource {'<%= fake_name %>':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => '<%= test_file_contents %>',
-  dsc_destinationpath => '<%= "C:\\" + test_dir_path + "\\" + fake_name %>',
-}
-MANIFEST
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_functionality', 'test_file_path.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 
 # Teardown
 teardown do

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
@@ -5,21 +5,16 @@ test_name 'FM-2623 - C68509 - Apply DSC Resource Manifest in "noop" Mode Using "
 
 confine(:to, :platform => 'windows')
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # ERB Manifest
 test_dir_path = SecureRandom.uuid
 fake_name = SecureRandom.uuid
+test_file_contents = SecureRandom.uuid
 
-dsc_manifest = <<-MANIFEST
-file { 'C:/<%= test_dir_path %>' :
-   ensure => 'directory'
-}
-->
-dsc_puppetfakeresource {'<%= fake_name %>':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => '<%= SecureRandom.uuid %>',
-  dsc_destinationpath => '<%= "C:\\" + test_dir_path + "\\" + fake_name %>',
-}
-MANIFEST
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_functionality', 'test_file_path.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 
 # Teardown
 teardown do

--- a/tests/integration/tests/basic_functionality/negative/dsc_on_linux.rb
+++ b/tests/integration/tests/basic_functionality/negative/dsc_on_linux.rb
@@ -4,6 +4,9 @@ require 'dsc_utils'
 require 'securerandom'
 test_name 'FM-2623 - C68790 - Attempt to Run DSC Manifest on a Linux Agent'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # Manifest
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid

--- a/tests/integration/tests/basic_functionality/puppet_agent_debug_dsc_manifest.rb
+++ b/tests/integration/tests/basic_functionality/puppet_agent_debug_dsc_manifest.rb
@@ -4,22 +4,16 @@ require 'dsc_utils'
 require 'securerandom'
 test_name 'FM-2623 - C68535 - Apply DSC Resource Manifest via "puppet agent" with Debug Enabled'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # ERB Manifest
 test_dir_path = SecureRandom.uuid
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid
 
-dsc_manifest = <<-MANIFEST
-file { 'C:/<%= test_dir_path %>' :
-   ensure => 'directory'
-}
-->
-dsc_puppetfakeresource {'<%= fake_name %>':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => '<%= test_file_contents %>',
-  dsc_destinationpath => '<%= "C:\\" + test_dir_path + "\\" + fake_name %>',
-}
-MANIFEST
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_functionality', 'test_file_path.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 
 # Verify
 debug_msg = /Debug:.*Dsc_puppetfakeresource\[#{fake_name}\]: The container Node\[default\] will propagate my refresh event/

--- a/tests/integration/tests/basic_functionality/puppet_agent_dsc_manifest.rb
+++ b/tests/integration/tests/basic_functionality/puppet_agent_dsc_manifest.rb
@@ -4,22 +4,16 @@ require 'dsc_utils'
 require 'securerandom'
 test_name 'FM-2798 - C68512 - Apply DSC Resource Manifest via "puppet agent"'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # ERB Manifest
 test_dir_path = SecureRandom.uuid
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid
 
-dsc_manifest = <<-MANIFEST
-file { 'C:/<%= test_dir_path %>' :
-   ensure => 'directory'
-}
-->
-dsc_puppetfakeresource {'<%= fake_name %>':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => '<%= test_file_contents %>',
-  dsc_destinationpath => '<%= "C:\\" + test_dir_path + "\\" + fake_name %>',
-}
-MANIFEST
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_functionality', 'test_file_path.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 
 # Teardown
 teardown do

--- a/tests/integration/tests/basic_functionality/puppet_agent_noop_dsc_manifest.rb
+++ b/tests/integration/tests/basic_functionality/puppet_agent_noop_dsc_manifest.rb
@@ -4,21 +4,16 @@ require 'dsc_utils'
 require 'securerandom'
 test_name 'FM-2623 - C68510 - Apply DSC Resource Manifest in "noop" Mode Using "puppet agent"'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # ERB Manifest
 test_dir_path = SecureRandom.uuid
 fake_name = SecureRandom.uuid
+test_file_contents = SecureRandom.uuid
 
-dsc_manifest = <<-MANIFEST
-file { 'C:/<%= test_dir_path %>' :
-   ensure => 'directory'
-}
-->
-dsc_puppetfakeresource {'<%= fake_name %>':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => '<%= SecureRandom.uuid %>',
-  dsc_destinationpath => '<%= "C:\\" + test_dir_path + "\\" + fake_name %>',
-}
-MANIFEST
+dsc_manifest_template_path = File.join(local_files_root_path, 'basic_functionality', 'test_file_path.pp.erb')
+dsc_manifest = ERB.new(File.read(dsc_manifest_template_path)).result(binding)
 
 # Teardown
 teardown do

--- a/tests/integration/tests/dsc_type/custom_resource_from_system_PSModulePath.rb
+++ b/tests/integration/tests/dsc_type/custom_resource_from_system_PSModulePath.rb
@@ -4,6 +4,8 @@ require 'dsc_utils'
 # this scenario works properly with only a single PuppetFakeResource in module path
 test_name 'Loads a custom DSC resource from system PSModulePath by ModuleName'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 # DSC runs in system context / can't use users module path
 pshome_modules_path = 'Windows/system32/WindowsPowerShell/v1.0/Modules'
 

--- a/tests/integration/tests/dsc_type/custom_resource_path.rb
+++ b/tests/integration/tests/dsc_type/custom_resource_path.rb
@@ -3,6 +3,9 @@ require 'master_manipulator'
 require 'dsc_utils'
 test_name 'Apply generic DSC Manifest to create a puppetfakeresource'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # Manifest
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid

--- a/tests/integration/tests/dsc_type/multiple_dsc_resources_in_PSModulePath.rb
+++ b/tests/integration/tests/dsc_type/multiple_dsc_resources_in_PSModulePath.rb
@@ -3,6 +3,8 @@ require 'master_manipulator'
 require 'dsc_utils'
 test_name 'Cannot load a DSC resource from PSModulePath by ModuleName when multiple versions exist'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
 # DSC runs in system context / cannot use users module path
 pshome_modules_path = 'Windows/system32/WindowsPowerShell/v1.0/Modules'
 program_files_modules_path = 'Program\ Files/WindowsPowerShell/Modules'

--- a/tests/integration/tests/dsc_type/psdesiredstateconfiguration.rb
+++ b/tests/integration/tests/dsc_type/psdesiredstateconfiguration.rb
@@ -3,6 +3,9 @@ require 'master_manipulator'
 require 'dsc_utils'
 test_name 'Apply generic DSC Manifest to create a standard DSC File'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # Manifest
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid

--- a/tests/integration/tests/ensure_behavior/ensure_absent.rb
+++ b/tests/integration/tests/ensure_behavior/ensure_absent.rb
@@ -3,6 +3,9 @@ require 'master_manipulator'
 require 'dsc_utils'
 test_name 'MODULES-2965 - C96624 - Apply DSC Manifest with "ensure" Set to "absent"'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # Manifest
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid

--- a/tests/integration/tests/ensure_behavior/ensure_absent_and_dsc_ensure_present.rb
+++ b/tests/integration/tests/ensure_behavior/ensure_absent_and_dsc_ensure_present.rb
@@ -3,6 +3,9 @@ require 'master_manipulator'
 require 'dsc_utils'
 test_name 'MODULES-2965 - C96627 - Apply DSC Manifest with "ensure" Set to "absent" and "dsc_ensure" Set to "present"'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # Manifest
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid

--- a/tests/integration/tests/ensure_behavior/ensure_and_dsc_ensure_absent.rb
+++ b/tests/integration/tests/ensure_behavior/ensure_and_dsc_ensure_absent.rb
@@ -3,6 +3,9 @@ require 'master_manipulator'
 require 'dsc_utils'
 test_name 'MODULES-2965 - C96629 - Apply DSC Manifest with "ensure" and "dsc_ensure" Set to "absent"'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # Manifest
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid

--- a/tests/integration/tests/ensure_behavior/ensure_and_dsc_ensure_present.rb
+++ b/tests/integration/tests/ensure_behavior/ensure_and_dsc_ensure_present.rb
@@ -3,6 +3,9 @@ require 'master_manipulator'
 require 'dsc_utils'
 test_name 'MODULES-2965 - C96625 - Apply DSC Manifest with "ensure" and "dsc_ensure" Set to "present"'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # Manifest
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid

--- a/tests/integration/tests/ensure_behavior/ensure_present.rb
+++ b/tests/integration/tests/ensure_behavior/ensure_present.rb
@@ -3,6 +3,9 @@ require 'master_manipulator'
 require 'dsc_utils'
 test_name 'MODULES-2965 - C96623 - Apply DSC Manifest with "ensure" Set to "present"'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # Manifest
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid

--- a/tests/integration/tests/ensure_behavior/ensure_present_and_dsc_ensure_absent.rb
+++ b/tests/integration/tests/ensure_behavior/ensure_present_and_dsc_ensure_absent.rb
@@ -3,6 +3,9 @@ require 'master_manipulator'
 require 'dsc_utils'
 test_name 'MODULES-2965 - C96626 - Apply DSC Manifest with "ensure" Set to "present" and "dsc_ensure" Set to "absent"'
 
+# Init
+local_files_root_path = ENV['MANIFESTS'] || 'tests/manifests'
+
 # Manifest
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid

--- a/tests/manifests/basic_functionality/test_file_path.pp.erb
+++ b/tests/manifests/basic_functionality/test_file_path.pp.erb
@@ -1,0 +1,9 @@
+file { 'C:/<%= test_dir_path %>' :
+   ensure => 'directory'
+}
+->
+dsc_puppetfakeresource {'<%= fake_name %>':
+  dsc_ensure          => 'present',
+  dsc_importantstuff  => '<%= test_file_contents %>',
+  dsc_destinationpath => '<%= defined?(test_file_path) ? test_file_path : "C:\\" + test_dir_path + "\\" + fake_name %>',
+}


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-dsc_lite#26

The inline templates used ERB `<%= %>` syntax instead of Ruby `#{}` syntax