### PR TITLE
(MODULES-6552) Use generic dsc type in Beaker manifests

### DIFF
--- a/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
@@ -4,21 +4,31 @@ test_name 'FM-2624 - C87654 - Apply DSC Resource Manifest with Multiple Failing 
 
 confine(:to, :platform => 'windows')
 
+installed_path = get_fake_reboot_resource_install_path(usage = :manifest)
+
 # In-line Manifest
 throw_message_1 = SecureRandom.uuid
 throw_message_2 = SecureRandom.uuid
 
 dsc_manifest = <<-MANIFEST
-dsc_puppetfakeresource {'throw_1':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => 'foo',
-  dsc_throwmessage    => '#{throw_message_1}',
+dsc { 'throw_1':
+  dsc_resource_name => 'puppetfakeresource',
+  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_properties => {
+    ensure          => 'present',
+    importantstuff  => 'foo',
+    throwmessage    => '#{throw_message_1}',
+  }
 }
 
-dsc_puppetfakeresource {'throw_2':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => 'bar',
-  dsc_throwmessage    => '#{throw_message_2}',
+dsc { 'throw_2':
+  dsc_resource_name => 'puppetfakeresource',
+  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_properties => {
+    ensure          => 'present',
+    importantstuff  => 'bar',
+    throwmessage    => '#{throw_message_2}',
+  }
 }
 MANIFEST
 

--- a/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
@@ -4,19 +4,29 @@ test_name 'FM-2624 - C68533 - Apply DSC Resource Manifest with Mix of Passing an
 
 confine(:to, :platform => 'windows')
 
+installed_path = get_fake_reboot_resource_install_path(usage = :manifest)
+
 # In-line Manifest
 throw_message = SecureRandom.uuid
 
 dsc_manifest = <<-MANIFEST
-dsc_puppetfakeresource {'good_resource':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => 'foo',
+dsc { 'good_resource':
+  dsc_resource_name => 'puppetfakeresource',
+  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_properties => {
+    ensure          => 'present',
+    importantstuff  => 'foo',
+  }
 }
 
-dsc_puppetfakeresource {'throw_resource':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => 'bar',
-  dsc_throwmessage    => '#{throw_message}',
+dsc { 'throw_resource':
+  dsc_resource_name => 'puppetfakeresource',
+  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_properties => {
+    ensure          => 'present',
+    importantstuff  => 'bar',
+    throwmessage    => '#{throw_message}',
+  }
 }
 MANIFEST
 

--- a/tests/acceptance/tests/basic_functionality/negative/dsc_on_linux.rb
+++ b/tests/acceptance/tests/basic_functionality/negative/dsc_on_linux.rb
@@ -4,20 +4,26 @@ require 'dsc_utils'
 require 'securerandom'
 test_name 'FM-2623 - C68790 - Attempt to Run DSC Manifest on a Linux Agent'
 
+installed_path = get_fake_reboot_resource_install_path(usage = :manifest)
+
 # Manifest
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid
 
 dsc_manifest = <<-MANIFEST
-dsc_puppetfakeresource {'#{fake_name}':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => '#{test_file_contents}',
-  dsc_destinationpath => 'C:\\#{fake_name}'
+dsc { '#{fake_name}':
+  dsc_resource_name => 'puppetfakeresource',
+  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_properties => {
+    ensure          => 'present',
+    importantstuff  => '#{test_file_contents}',
+    destinationpath => 'C:\\#{fake_name}',
+  },
 }
 MANIFEST
 
 # Verify
-error_msg = /Could not find a suitable provider for dsc_puppetfakeresource/
+error_msg = /Could not find a suitable provider for dsc/
 
 # Teardown
 teardown do

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
@@ -3,6 +3,8 @@ require 'dsc_utils'
 require 'securerandom'
 test_name 'FM-2623 - C68509 - Apply DSC Resource Manifest in "noop" Mode Using "puppet apply"'
 
+installed_path = get_fake_reboot_resource_install_path(usage = :manifest)
+
 confine(:to, :platform => 'windows')
 
 # ERB Manifest
@@ -14,10 +16,14 @@ file { 'C:/#{ test_dir_path }' :
    ensure => 'directory'
 }
 ->
-dsc_puppetfakeresource {'#{ fake_name }':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => '#{ SecureRandom.uuid }',
-  dsc_destinationpath => '#{ "C:\\" + test_dir_path + "\\" + fake_name }',
+dsc { '#{fake_name}':
+  dsc_resource_name => 'puppetfakeresource',
+  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_properties => {
+    ensure          => 'present',
+    importantstuff  => '#{SecureRandom.uuid}',
+    destinationpath => '#{"C:\\" + test_dir_path + "\\" + fake_name}',
+  },
 }
 MANIFEST
 

--- a/tests/acceptance/tests/dsc_type/custom_resource_from_system_PSModulePath.rb
+++ b/tests/acceptance/tests/dsc_type/custom_resource_from_system_PSModulePath.rb
@@ -42,11 +42,7 @@ confine_block(:to, :platform => 'windows') do
   install_fake_reboot_resource(agent)
 
   step 'Copy PuppetFakeResource implementation to system PSModulePath'
-  is_pluginsync = hosts.any? { |h| h['roles'].include?('master') }
-  install_base = '/cygdrive/c/ProgramData/PuppetLabs/' +
-    (is_pluginsync ? 'puppet/cache' : 'code/modules/dsc')
-
-  installed_path = "#{install_base}/lib/puppet_x/dsc_resources"
+  installed_path = get_fake_reboot_resource_install_path(usage = :cygwin)
 
   # put PuppetFakeResource in $PSHome\Modules
   on(agents, <<-CYGWIN)

--- a/tests/acceptance/tests/dsc_type/custom_resource_path.rb
+++ b/tests/acceptance/tests/dsc_type/custom_resource_path.rb
@@ -3,12 +3,7 @@ require 'master_manipulator'
 require 'dsc_utils'
 test_name 'Apply generic DSC Manifest to create a puppetfakeresource'
 
-# Master or masterless determine content locations
-is_pluginsync = hosts.any? { |h| h['roles'].include?('master') }
-install_base = 'C:/ProgramData/PuppetLabs/' +
-  (is_pluginsync ? 'puppet/cache' : 'code/modules/dsc')
-
-installed_path = "#{install_base}/lib/puppet_x/dsc_resources"
+installed_path = get_fake_reboot_resource_install_path(usage = :manifest)
 
 # Manifest
 fake_name = SecureRandom.uuid

--- a/tests/acceptance/tests/dsc_type/multiple_dsc_resources_in_PSModulePath.rb
+++ b/tests/acceptance/tests/dsc_type/multiple_dsc_resources_in_PSModulePath.rb
@@ -32,11 +32,7 @@ confine_block(:to, :platform => 'windows') do
 
   step 'Copy PuppetFakeResource implementations to system PSModulePath locations'
   # sourced from different directory
-  is_pluginsync = hosts.any? { |h| h['roles'].include?('master') }
-  install_base = '/cygdrive/c/ProgramData/PuppetLabs/' +
-    (is_pluginsync ? 'puppet/cache' : 'code/modules/dsc')
-
-  installed_path = "#{install_base}/lib/puppet_x/dsc_resources"
+  installed_path = get_fake_reboot_resource_install_path(usage = :cygwin)
 
   # put PuppetFakeResource v1 in $PSHome\Modules
   on(agents, <<-CYGWIN)

--- a/tests/acceptance/tests/ensure_behavior/ensure_and_dsc_ensure_present.rb
+++ b/tests/acceptance/tests/ensure_behavior/ensure_and_dsc_ensure_present.rb
@@ -3,15 +3,21 @@ require 'master_manipulator'
 require 'dsc_utils'
 test_name 'MODULES-2965 - C96625 - Apply DSC Manifest with "ensure" and "dsc_ensure" Set to "present"'
 
+installed_path = get_fake_reboot_resource_install_path(usage = :manifest)
+
 # Manifest
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
-dsc_puppetfakeresource {'#{fake_name}':
-  ensure              => 'present',
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => '#{test_file_contents}',
-  dsc_destinationpath => 'C:\\#{fake_name}'
+dsc { '#{fake_name}':
+  dsc_resource_name => 'puppetfakeresource',
+  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_properties => {
+    ensure          => 'present',
+    importantstuff  => '#{test_file_contents}',
+    destinationpath => 'C:\\#{fake_name}',
+  },
+  ensure => 'present',
 }
 MANIFEST
 

--- a/tests/acceptance/tests/ensure_behavior/ensure_present.rb
+++ b/tests/acceptance/tests/ensure_behavior/ensure_present.rb
@@ -3,15 +3,20 @@ require 'master_manipulator'
 require 'dsc_utils'
 test_name 'MODULES-2965 - C96623 - Apply DSC Manifest with "ensure" Set to "present"'
 
+installed_path = get_fake_reboot_resource_install_path(usage = :manifest)
+
 # Manifest
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
-dsc_puppetfakeresource {'#{fake_name}':
-  # NOTE: setting ensure does not automatically set a dsc_ensure with same value
-  ensure              => 'present',
-  dsc_importantstuff  => '#{test_file_contents}',
-  dsc_destinationpath => 'C:\\#{fake_name}'
+dsc { '#{fake_name}':
+  dsc_resource_name => 'puppetfakeresource',
+  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_properties => {
+    importantstuff  => '#{test_file_contents}',
+    destinationpath => 'C:\\#{fake_name}',
+  },
+  ensure => 'present',
 }
 MANIFEST
 

--- a/tests/acceptance/tests/ensure_behavior/ensure_present_and_dsc_ensure_absent.rb
+++ b/tests/acceptance/tests/ensure_behavior/ensure_present_and_dsc_ensure_absent.rb
@@ -3,14 +3,20 @@ require 'master_manipulator'
 require 'dsc_utils'
 test_name 'MODULES-2965 - C96626 - Apply DSC Manifest with "ensure" Set to "present" and "dsc_ensure" Set to "absent"'
 
+installed_path = get_fake_reboot_resource_install_path(usage = :manifest)
+
 # Manifest
 fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
-dsc_puppetfakeresource {'#{fake_name}':
-  dsc_ensure          => 'present',
-  dsc_importantstuff  => '#{test_file_contents}',
-  dsc_destinationpath => 'C:\\#{fake_name}'
+dsc { '#{fake_name}':
+  dsc_resource_name => 'puppetfakeresource',
+  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_properties => {
+    ensure          => 'present',
+    importantstuff  => '#{test_file_contents}',
+    destinationpath => 'C:\\#{fake_name}',
+  },
 }
 MANIFEST
 
@@ -41,11 +47,15 @@ end
 
 # New manifest to remove value.
 dsc_remove_manifest = <<-MANIFEST
-dsc_puppetfakeresource {'#{fake_name}':
-  ensure              => 'present',
-  dsc_ensure          => 'absent',
-  dsc_importantstuff  => '#{test_file_contents}',
-  dsc_destinationpath => 'C:\\#{fake_name}'
+dsc { '#{fake_name}':
+  dsc_resource_name => 'puppetfakeresource',
+  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_properties => {
+    ensure          => 'absent',
+    importantstuff  => '#{test_file_contents}',
+    destinationpath => 'C:\\#{fake_name}',
+  },
+  ensure => 'present',
 }
 MANIFEST
 

--- a/tests/lib/dsc_utils.rb
+++ b/tests/lib/dsc_utils.rb
@@ -92,6 +92,18 @@ def install_fake_reboot_resource(host)
   end
 end
 
+def get_fake_reboot_resource_install_path(usage = :manifest)
+  # Master or masterless determine content locations
+  is_pluginsync = hosts.any? { |h| h['roles'].include?('master') }
+
+  install_root = usage == :manifest ? 'C:/' : '/cygdrive/c'
+
+  install_base = "#{install_root}/ProgramData/PuppetLabs/" +
+    (is_pluginsync ? 'puppet/cache' : 'code/modules/dsc')
+
+  installed_path = "#{install_base}/lib/puppet_x/dsc_resources"
+end
+
 # Remove the "PuppetFakeResource" module on target host.
 #
 # ==== Attributes


### PR DESCRIPTION
Note that there are a few tests that did not yet work with the new `dsc` resource:

#### `ensure` on Puppet resource vs `ensure` in `dsc_resource_properties` based tests:

* ensure_absent_and_dsc_ensure_present.rb
* ensure_and_dsc_ensure_absent.rb

#### All Reboot tests

The current resource does not have the same code as the type wrapper for hooking up with the reboot resource.


I suggest for both of these additional tickets be filed to address as it's new functionality not yet implemented in the generic resource.
