### PR TITLE
(maint) Allow reboot 2.0+ module dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/reboot",
-      "version_requirement": ">= 1.2.1 < 2.0.0"
+      "version_requirement": ">= 1.2.1 < 3.0.0"
     }
   ]
 }


### PR DESCRIPTION
I had been using the 2.0.0 version of the reboot module and noticed that when using PMT to install dsc_lite it blows up because the module i have locally doesn't fall within an acceptable version for dsc_lite as specified in the metadata.json.  Just bumping the dependency and would like someone to review to make sure they don't forsee any issues with this.
