### PR TITLE
(MODULES-7141) Support Sensitive data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,29 @@ dsc {'foouser':
 
 Some DSC Resources require a password or passphrase for a setting, but do not need a user name. All credentials in DSC must be a PSCredential, so these passwords still have to be specified in a PSCredential format, even if there is no `user` to specify. How you specify the PSCredential will depend on how the DSC Resource implemented the password requirement. Some DSC Resources will accept an empty or null string for `user`, others do not. If it does not accept an empty or null string, then specify a dummy value. Do not use `undef` as it will error out.
 
+You can also use the Puppet [Sensitive type](https://puppet.com/docs/puppet/latest/lang_data_sensitive.html) to ensure logs and reports redact the password.
+
+~~~puppet
+dsc {'foouser':
+  dsc_resource_name       => 'User',
+  dsc_resource_module     => 'PSDesiredStateConfiguration',
+  dsc_resource_properties => {
+    'username'    => 'jane-doe',
+    'description' => 'Jane Doe user',
+    'ensure'      => 'present',
+    'password'    => {
+      'dsc_type'       => 'MSFT_Credential',
+      'dsc_properties' => {
+        'user'     => 'jane-doe',
+        'password' => Sensitive('StartFooo123&^!')
+      }
+    },
+    'passwordneverexpires' => false,
+    'disabled'             => true,
+  }
+}
+~~~
+
 ### Using CimInstance
 
 A DSC Resource may need a more complex type than a simple key value pair, so an EmbeddedInstance is used. An EmbeddedInstance is serialized as CimInstance over the wire. In order to represent a CimInstance in the `dsc` type, we will use the `dsc_type` key to specify which CimInstance to use. If the CimInstance is an array, we append a `[]` to the end of the name.

--- a/lib/puppet/provider/base_dsc_lite/powershell.rb
+++ b/lib/puppet/provider/base_dsc_lite/powershell.rb
@@ -167,6 +167,8 @@ EOT
       "@(" + dsc_value.collect{|m| format_dsc_value(m)}.join(', ') + ")"
     when dsc_value.class.name == 'Hash'
       "@{" + dsc_value.collect{|k, v| format_dsc_value(k) + ' = ' + format_dsc_value(v)}.join('; ') + "}"
+    when dsc_value.class.name == 'Puppet::Pops::Types::PSensitiveType::Sensitive'
+      "'#{escape_quotes(dsc_value.unwrap)}'"
     else
       fail "unsupported type #{dsc_value.class} of value '#{dsc_value}'"
     end

--- a/lib/puppet_x/puppetlabs/dsc_lite/dsc_type_helpers.rb
+++ b/lib/puppet_x/puppetlabs/dsc_lite/dsc_type_helpers.rb
@@ -48,8 +48,10 @@ module PuppetX
         required = ['user', 'password']
         required.each do |key|
           if value[key]
-            fail "#{key} for #{name} should be a String" unless value[key].is_a? String
-            fail "#{key} must not be empty" if value[key].empty?
+            unless (value[key].is_a? String) || (value[key].is_a? Puppet::Pops::Types::PSensitiveType::Sensitive)
+              fail "#{key} for #{name} should be a String or Sensitive value"
+            end
+            fail "#{key} must not be empty" if value[key].to_s.empty?
           end
         end
 

--- a/lib/puppet_x/puppetlabs/dsc_lite/powershell_hash_formatter.rb
+++ b/lib/puppet_x/puppetlabs/dsc_lite/powershell_hash_formatter.rb
@@ -17,6 +17,8 @@ module PuppetX
             self.format_array(dsc_value)
           when dsc_value.class.name == 'Hash'
             self.format_hash(dsc_value)
+          when dsc_value.class.name == 'Puppet::Pops::Types::PSensitiveType::Sensitive'
+            "'#{escape_quotes(dsc_value.unwrap)}'"
           else
             fail "unsupported type #{dsc_value.class} of value '#{dsc_value}'"
           end

--- a/spec/integration/puppet_x/puppetlabs/powershell_hash_formatter_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_hash_formatter_spec.rb
@@ -196,6 +196,38 @@ HERE
         expect(result).to eq expected.strip
       end
 
+      it "should output correct syntax with Sensitive MSFT_Credential" do
+        expected = <<-HERE
+@{
+'username' = 'jane-doe';
+'description' = 'Jane Doe user';
+'ensure' = 'present';
+'password' = ([PSCustomObject]@{
+'user' = 'jane-doe';
+'password' = 'password'
+} | new-pscredential);
+'passwordneverexpires' = $false;
+'disabled' = $true
+}
+HERE
+        sensitive_pass = Puppet::Pops::Types::PSensitiveType::Sensitive.new('password')
+        result = @formatter.format({
+          'username'    => 'jane-doe',
+          'description' => 'Jane Doe user',
+          'ensure'      => 'present',
+          'password'    => {
+            'dsc_type'       => 'MSFT_Credential',
+            'dsc_properties' => {
+              'user'     => 'jane-doe',
+              'password' => sensitive_pass
+            }
+          },
+          'passwordneverexpires' => false,
+          'disabled'             => true,
+        })
+        expect(result).to eq expected.strip
+      end
+
     end
   end
 end

--- a/spec/unit/puppet_x/puppetlabs/dsc_type_helpers_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/dsc_type_helpers_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'puppet_x/puppetlabs/dsc_lite/dsc_type_helpers'
+
+describe PuppetX::DscLite::TypeHelpers do
+  describe "#validate_MSFT_Credential" do
+
+    it "should allow plaintext strings as passwords" do
+      cred = { 'user' => 'bob', 'password' => 'password' }
+      expect {
+        subject.class.validate_MSFT_Credential('foo', cred)
+      }.to_not raise_error
+    end
+
+    it "should allow Sensitive type passwords" do
+      sensitive_pass = Puppet::Pops::Types::PSensitiveType::Sensitive.new('password')
+      cred = { 'user' => 'bob', 'password' => sensitive_pass }
+      expect {
+        subject.class.validate_MSFT_Credential('foo', cred)
+      }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
This is a port of the code in [puppetlabs-dsc PR#324](https://github.com/puppetlabs/puppetlabs-dsc/pull/324) to add Sensitive types to the dsc_lite module.