### PR TITLE
(maint) Remove appveyor 4.2.3 Puppet testing

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -20,9 +20,6 @@ spec/spec_helper.rb:
   - 'vendor/'
 appveyor.yml:
   appveyor_bundle_install: "bundle install --jobs 4 --retry 2 --without system_tests build"
-  matrix_extras:
-    - PUPPET_GEM_VERSION: 4.2.3
-      RUBY_VER: 21-x64
   test_script:
     - 'bundle exec rspec spec/unit spec/integration -fd -b'
 MAINTAINERS.md:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,6 @@ environment:
     RUBY_VER: 24-x64
   - PUPPET_GEM_VERSION: 4.7.1
     RUBY_VER: 21-x64
-  - PUPPET_GEM_VERSION: 4.2.3
-    RUBY_VER: 21-x64
 matrix:
   fast_finish: true
 install:


### PR DESCRIPTION
Manually remove Puppet 4.2.3 testing from modulesync and appveyor as it
is no longer necessary.