### PR TITLE
(MODULES-7143) add UTF-8 encoding to ERB templates.

### DIFF
--- a/lib/puppet/provider/base_dsc_lite/powershell.rb
+++ b/lib/puppet/provider/base_dsc_lite/powershell.rb
@@ -190,7 +190,8 @@ EOT
     template_name = resource.type == :dsc ?
       '/invoke_generic_dsc_resource.ps1.erb' :
       '/invoke_dsc_resource.ps1.erb'
-    template = ERB.new(File.new(template_path + template_name).read, nil, '-')
+    file = File.new(template_path + template_name, :encoding => Encoding::UTF_8)
+    template = ERB.new(file.read, nil, '-')
     template.result(binding)
   end
 end

--- a/tests/acceptance/tests/unicode/puppet_apply_utf8_file_name.rb
+++ b/tests/acceptance/tests/unicode/puppet_apply_utf8_file_name.rb
@@ -1,0 +1,92 @@
+require 'erb'
+require 'master_manipulator'
+require 'dsc_utils'
+test_name 'Apply generic DSC Manifest with UTF-8 file name to create a puppetfakeresource'
+
+installed_path = get_fake_reboot_resource_install_path(usage = :manifest)
+
+# different UTF-8 widths
+# 1-byte A
+# 2-byte ۿ - http://www.fileformat.info/info/unicode/char/06ff/index.htm - 0xDB 0xBF / 219 191
+# 3-byte ᚠ - http://www.fileformat.info/info/unicode/char/16A0/index.htm - 0xE1 0x9A 0xA0 / 225 154 160
+# 4-byte 𠜎 - http://www.fileformat.info/info/unicode/char/2070E/index.htm - 0xF0 0xA0 0x9C 0x8E / 240 160 156 142
+MIXED_UTF8 = "A\u06FF\u16A0\u{2070E}" # Aۿᚠ𠜎
+
+# Manifest
+file_name = MIXED_UTF8
+file_path = SecureRandom.uuid
+test_file_contents = SecureRandom.uuid
+dsc_manifest = <<-MANIFEST
+dsc {'some_name':
+  dsc_resource_name => 'puppetfakeresource',
+  # NOTE: install_fake_reboot_resource installs on master, which pluginsyncs here
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_properties => {
+    ensure          => 'present',
+    importantstuff  => '#{test_file_contents}',
+    destinationpath => 'C:\\#{file_path}\\#{file_name}'
+  }
+}
+MANIFEST
+
+# Teardown
+teardown do
+  confine_block(:to, :platform => 'windows') do
+    step 'Remove Test Artifacts'
+    agents.each do |agent|
+      uninstall_fake_reboot_resource(agent)
+    end
+    on(agents, "rm -rf C:/#{file_path}")
+  end
+end
+
+# Tests
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'setup'
+    on(agent, powershell("mkdir /#{file_path}"))
+
+    step 'Copy Test Type Wrappers'
+    install_fake_reboot_resource(agent)
+
+    step 'Run Puppet Apply'
+    on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step 'Verify Results'
+    powershell_cmd = "'Write-Host (Get-ChildItem C:\\#{file_path}  -Filter '#{file_name}' | Measure-Object ).Count;'"
+    on(agent, powershell(powershell_cmd)) do |result|
+      assert('1' == result.stdout.to_s.strip, 'File with correct UTF-8 characters was not present.')
+    end
+  end
+end
+
+# New manifest to remove value.
+dsc_remove_manifest = <<-MANIFEST
+dsc {'some_name':
+  dsc_resource_name => 'puppetfakeresource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_properties => {
+    ensure          => 'absent',
+    importantstuff  => '#{test_file_contents}',
+    destinationpath => 'C:\\#{file_path}\\#{file_name}'
+  }
+}
+MANIFEST
+
+confine_block(:to, :platform => 'windows') do
+  agents.each do |agent|
+    step 'Apply Manifest to Remove File'
+    on(agent, puppet('apply'), :stdin => dsc_remove_manifest, :acceptable_exit_codes => [0,2]) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+
+    step 'Verify Results'
+    # if the file count is greater than 0, 'absent' didn't work
+    powershell_cmd = "'Write-Host (Get-ChildItem C:\\#{file_path} -Filter '#{file_name}' | Measure-Object ).Count;'"
+    on(agent, powershell(powershell_cmd)) do |result|
+      assert('0' == result.stdout.to_s.strip, 'File with UTF-8 character name was not removed')
+    end
+  end
+end


### PR DESCRIPTION
This PR adds UTF-8 support for fields inside of custom dsc templates.

It does not support the template custom name itself being in UTF-8, but parameters passed to fields in the template can now be UTF-8.

Also added an integration test for this functionality.