### PR TITLE
(MODULES-7253) Replace verbose parameter names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Changed
+
+- **BREAKING:**  Renamed all parameters for resource declarations, will require manifest modifications. [(MODULES-7253)](https://tickets.puppetlabs.com/browse/MODULES-7253).
+
+
 ## 2018-06-07 - Unsupported Release 0.4.0
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See [known issues](#known-issues) for troubleshooting setup.
 
 ## Usage
 
-The generic `dsc` type is a streamlined and minimal representation of a DSC Resource declaration in Puppet syntax. You can use a DSC Resource by supplying the same properties you would set in a DSC Configuration script inside the `dsc_resource_properties` parameter. For most use cases the `dsc_resource_properties` parameter accepts the same structure as the PowerShell syntax, with the substitution of Puppet syntax for arrays, hashes and other data structures.
+The generic `dsc` type is a streamlined and minimal representation of a DSC Resource declaration in Puppet syntax. You can use a DSC Resource by supplying the same properties you would set in a DSC Configuration script inside the `properties` parameter. For most use cases the `properties` parameter accepts the same structure as the PowerShell syntax, with the substitution of Puppet syntax for arrays, hashes and other data structures.
 
 So a DSC resource specified in PowerShell...
 
@@ -57,9 +57,9 @@ WindowsFeature IIS {
 
 ~~~puppet
 dsc {'iis':
-  dsc_resource_name        => 'WindowsFeature',
-  dsc_resource_module      => 'PSDesiredStateConfiguration',
-  dsc_resource_properties  => {
+  resource_name        => 'WindowsFeature',
+  module      => 'PSDesiredStateConfiguration',
+  properties  => {
     ensure => 'present',
     name   => 'Web-Server',
   }
@@ -68,15 +68,15 @@ dsc {'iis':
 
 For the simplest cases, the above example is enough. However there are more advanced use cases in DSC that require more custom syntax in the `dsc` Puppet type. Since the `dsc` Puppet type has no prior knowledge of the type for each property in a DSC Resource, it can't format the hash correctly without some hints.
 
-The `dsc_resource_properties` parameter will recognize any key with a hash value that contains two keys: `dsc_type` and `dsc_properties`, as a indication of how to format the data supplied. The `dsc_type` contains the CimInstance name to use, and the `dsc_properties` contains a hash or an array of hashes representing the data for the CimInstances.
+The `properties` parameter will recognize any key with a hash value that contains two keys: `dsc_type` and `dsc_properties`, as a indication of how to format the data supplied. The `dsc_type` contains the CimInstance name to use, and the `dsc_properties` contains a hash or an array of hashes representing the data for the CimInstances.
 
 A contrived, but simple example follows:
 
 ~~~puppet
 dsc {'foo':
-  dsc_resource_name        => 'xFoo',
-  dsc_resource_module      => 'xFooBar',
-  dsc_resource_properties  => {
+  resource_name        => 'xFoo',
+  module      => 'xFooBar',
+  properties  => {
     ensure  => 'present',
     fooinfo => {
       'dsc_type'       => 'FooBarBaz',
@@ -95,12 +95,12 @@ When there is more than one version installed for a given DSC Resource module, y
 
 ~~~puppet
 dsc {'iis_server':
-  dsc_resource_name   => 'WindowsFeature',
-  dsc_resource_module => {
+  resource_name   => 'WindowsFeature',
+  module => {
     name    => 'PSDesiredStateConfiguration',
     version => '1.1'
   },
-  dsc_resource_properties  => {
+  properties  => {
     ensure => 'present',
     name   => 'Web-Server',
   }
@@ -159,9 +159,9 @@ Specifying credentials in DSC Resources requires using a PSCredential object. Th
 
 ~~~puppet
 dsc {'foouser':
-  dsc_resource_name       => 'User',
-  dsc_resource_module     => 'PSDesiredStateConfiguration',
-  dsc_resource_properties => {
+  resource_name       => 'User',
+  module     => 'PSDesiredStateConfiguration',
+  properties => {
     'username'    => 'jane-doe',
     'description' => 'Jane Doe user',
     'ensure'      => 'present',
@@ -184,9 +184,9 @@ You can also use the Puppet [Sensitive type](https://puppet.com/docs/puppet/late
 
 ~~~puppet
 dsc {'foouser':
-  dsc_resource_name       => 'User',
-  dsc_resource_module     => 'PSDesiredStateConfiguration',
-  dsc_resource_properties => {
+  resource_name       => 'User',
+  module     => 'PSDesiredStateConfiguration',
+  properties => {
     'username'    => 'jane-doe',
     'description' => 'Jane Doe user',
     'ensure'      => 'present',
@@ -211,9 +211,9 @@ For example, we'll create a new IIS website using the xWebSite DSC Resource, bou
 
 ~~~puppet
 dsc {'NewWebsite':
-  dsc_resource_name        => 'xWebsite',
-  dsc_resource_module      => 'xWebAdministration',
-  dsc_resource_properties  => {
+  resource_name        => 'xWebsite',
+  module      => 'xWebAdministration',
+  properties  => {
     ensure       => 'Present',
     state        => 'Started',
     name         => 'TestSite',
@@ -233,9 +233,9 @@ To show using more than one value in `dsc_properties`, let's create the same sit
 
 ~~~puppet
 dsc {'NewWebsite':
-  dsc_resource_name        => 'xWebsite',
-  dsc_resource_module      => 'xWebAdministration',
-  dsc_resource_properties  => {
+  resource_name        => 'xWebsite',
+  module      => 'xWebAdministration',
+  properties  => {
     ensure       => 'Present',
     state        => 'Started',
     name         => 'TestSite',
@@ -293,19 +293,19 @@ An optional property that specifies that the DSC resource should be invoked.
 This property has only one value of `present`.
 This property does not need be be set in manifests.
 
-#### dsc_resource_name
+#### resource_name
 
 The name of the DSC Resource to use. For example, the xRemoteFile DSC Resource.
 
-#### dsc_resource_module
+#### module
 
 The name of the DSC Resource module to use. For example, the xPSDesiredStateConfiguration DSC Resource module contains the xRemoteFile DSC Resource.
 
-#### dsc_resource_properties
+#### properties
 
 The hash of properties to pass to the DSC Resource.
 
-To express EmbeddedInstances, the `dsc_resource_properties` parameter will recognize any key with a hash value that contains two keys: `dsc_type` and `dsc_properties`, as a indication of how to format the data supplied. The `dsc_type` contains the CimInstance name to use, and the `dsc_properties` contains a hash or an array of hashes representing the data for the CimInstances. If the CimInstance is an array, we append a `[]` to the end of the name.
+To express EmbeddedInstances, the `properties` parameter will recognize any key with a hash value that contains two keys: `dsc_type` and `dsc_properties`, as a indication of how to format the data supplied. The `dsc_type` contains the CimInstance name to use, and the `dsc_properties` contains a hash or an array of hashes representing the data for the CimInstances. If the CimInstance is an array, we append a `[]` to the end of the name.
 
 ## Limitations
 

--- a/README_Tradeoffs.md
+++ b/README_Tradeoffs.md
@@ -23,9 +23,9 @@ You'll write a simplified declaration that looks like this:
 
 ```puppet
 dsc {'fruit_file':
-  dsc_resource_name => 'File',
-  dsc_resource_module => 'PSDesiredStateConfiguration',
-  dsc_resource_properties => {
+  resource_name => 'File',
+  module => 'PSDesiredStateConfiguration',
+  properties => {
     ensure          => 'present',
     content         => 'Apple, Banana, Cherry.',
     destinationpath => 'C:\\Fruit.txt',
@@ -108,9 +108,9 @@ If we do the same with the new `dsc_lite` module:
 
 ```puppet
 dsc {'fruit_file':
-  dsc_resource_name => 'File',
-  dsc_resource_module => 'PSDesiredStateConfiguration',
-  dsc_resource_properties => {
+  resource_name => 'File',
+  module => 'PSDesiredStateConfiguration',
+  properties => {
     ensure          => 'present',
     destinationpath => 1,
   }

--- a/lib/puppet/provider/base_dsc_lite/invoke_generic_dsc_resource.ps1.erb
+++ b/lib/puppet/provider/base_dsc_lite/invoke_generic_dsc_resource.ps1.erb
@@ -22,14 +22,14 @@ $response = @{
 }
 
 $invokeParams = @{
-Name       = '<%= resource.parameters[:dsc_resource_name].value %>'
-ModuleName = <% if resource.parameters[:dsc_resource_module].value.is_a?(Hash) -%>
+Name       = '<%= resource.parameters[:resource_name].value %>'
+ModuleName = <% if resource.parameters[:module].value.is_a?(Hash) -%>
 @{
-modulename    = '<%= resource.parameters[:dsc_resource_module].value['name'] %>'
-moduleversion = '<%= resource.parameters[:dsc_resource_module].value['version'] %>'
+modulename    = '<%= resource.parameters[:module].value['name'] %>'
+moduleversion = '<%= resource.parameters[:module].value['version'] %>'
 }
 <% else -%>
-'<%= resource.parameters[:dsc_resource_module].value %>'
+'<%= resource.parameters[:module].value %>'
 <% end -%>
 Method     = '<%= dsc_invoke_method %>'
 Property   = <% provider.dsc_property_param.each do |p| -%>

--- a/lib/puppet/provider/base_dsc_lite/powershell.rb
+++ b/lib/puppet/provider/base_dsc_lite/powershell.rb
@@ -50,7 +50,7 @@ EOT
   end
 
   def dsc_property_param
-    resource.parameters_with_value.select{ |pr| pr.name == :dsc_resource_properties }.each do |p|
+    resource.parameters_with_value.select{ |pr| pr.name == :properties }.each do |p|
       p.name.to_s =~ /dsc_/
     end
   end

--- a/lib/puppet/type/dsc.rb
+++ b/lib/puppet/type/dsc.rb
@@ -30,7 +30,7 @@ HERE
     end
   end
 
-  newparam(:dsc_resource_name) do
+  newparam(:resource_name) do
     desc "DSC Resource Name"
     isrequired
     validate do |value|
@@ -41,7 +41,7 @@ HERE
     end
   end
 
-  newparam(:dsc_resource_module) do
+  newparam(:module) do
     desc "DSC Resource Module"
     isrequired
     validate do |value|
@@ -58,11 +58,11 @@ HERE
     end
   end
 
-  newparam(:dsc_resource_properties, :array_matching => :all) do
+  newparam(:properties, :array_matching => :all) do
     desc <<-HERE
     The hash of properties to pass to the DSC Resource.
 
-    To express EmbeddedInstances, the dsc_resource_properties parameter will reconize any key with a hash value that contains two keys: dsc_type and dsc_properties, as a indication of how to format the data supplied. The dsc_type contains the CimInstance name to use, and the dsc_properties contains a hash or an array of hashes representing the data for the CimInstances. If the CimInstance is an array, we append a [] to the end of the name.
+    To express EmbeddedInstances, the properties parameter will reconize any key with a hash value that contains two keys: dsc_type and dsc_properties, as a indication of how to format the data supplied. The dsc_type contains the CimInstance name to use, and the dsc_properties contains a hash or an array of hashes representing the data for the CimInstances. If the CimInstance is an array, we append a [] to the end of the name.
 HERE
     isrequired
     validate do |value|

--- a/spec/unit/puppet/type/dsc_spec.rb
+++ b/spec/unit/puppet/type/dsc_spec.rb
@@ -38,8 +38,8 @@ describe Puppet::Type.type(:dsc) do
     end
   end
 
-  describe "parameter :dsc_resource_name" do
-    subject { resource.parameters[:dsc_resource_name] }
+  describe "parameter :resource_name" do
+    subject { resource.parameters[:resource_name] }
     
     it "should not allow nil" do
       expect {
@@ -66,68 +66,68 @@ describe Puppet::Type.type(:dsc) do
     end
   end
   
-  describe "parameter :dsc_resource_module" do
-    subject { resource.parameters[:dsc_resource_module] }
+  describe "parameter :module" do
+    subject { resource.parameters[:module] }
     
     it "should allow a string" do
       expect {
-        resource[:dsc_resource_module] = 'foo'
+        resource[:module] = 'foo'
       }
     end
 
     it "should allow a hash" do
       expect {
-        resource[:dsc_resource_module] = { 'name' => 'bar', 'version' => '1.8' }
+        resource[:module] = { 'name' => 'bar', 'version' => '1.8' }
       }.not_to raise_error
     end
 
     it "should require name and version keys if hash" do
       expect {
-        resource[:dsc_resource_module] = { 'foo' => 'bar'}
+        resource[:module] = { 'foo' => 'bar'}
       }.to raise_error(Puppet::Error, /Must specify name and version if using ModuleSpecification/)
     end
 
     it "should not allow nil" do
       expect {
-        resource[:dsc_resource_module] = nil
-      }.to raise_error(Puppet::Error, /Got nil value for dsc_resource_module/)
+        resource[:module] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for module/)
     end
 
     it "should not allow empty" do
       expect {
-        resource[:dsc_resource_module] = ''
-      }.to raise_error(Puppet::ResourceError, /A non-empty dsc_resource_module must/)
+        resource[:module] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty module must/)
     end
     
     [ 'value', 'value with spaces', 'UPPER CASE', '0123456789_-', 'With.Period' ].each do |value|
       it "should accept '#{value}'" do
-        expect { resource[:dsc_resource_module] = value }.not_to raise_error
+        expect { resource[:module] = value }.not_to raise_error
       end
     end
   end
   
-  describe "parameter :dsc_resource_properties" do
-    subject { resource.parameters[:dsc_resource_properties] }
+  describe "parameter :properties" do
+    subject { resource.parameters[:properties] }
     
     it "should not allow nil" do
       expect {
-        resource[:dsc_resource_properties] = nil
-      }.to raise_error(Puppet::Error, /Got nil value for dsc_resource_properties/)
+        resource[:properties] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for properties/)
     end
 
     it "should not allow empty" do
       expect {
-        resource[:dsc_resource_properties] = ''
-      }.to raise_error(Puppet::ResourceError, /A non-empty dsc_resource_properties must be specified/)
+        resource[:properties] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty properties must be specified/)
     end
     
     it "requires a hash or array of hashes" do
       expect {
-        resource[:dsc_resource_properties] = "hi"
-      }.to raise_error(Puppet::Error, /dsc_resource_properties should be a Hash/)
+        resource[:properties] = "hi"
+      }.to raise_error(Puppet::Error, /properties should be a Hash/)
       expect {
-        resource[:dsc_resource_properties] = ["hi"]
-      }.to raise_error(Puppet::Error, /dsc_resource_properties should be a Hash/)
+        resource[:properties] = ["hi"]
+      }.to raise_error(Puppet::Error, /properties should be a Hash/)
     end
   end
 end

--- a/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
@@ -10,9 +10,9 @@ throw_message_2 = SecureRandom.uuid
 
 dsc_manifest = <<-MANIFEST
 dsc { 'throw_1':
-  dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module => '#{installed_path}/1.0',
-  dsc_resource_properties => {
+  resource_name => 'puppetfakeresource',
+  module => '#{installed_path}/1.0',
+  properties => {
     ensure          => 'present',
     importantstuff  => 'foo',
     throwmessage    => '#{throw_message_1}',
@@ -20,9 +20,9 @@ dsc { 'throw_1':
 }
 
 dsc { 'throw_2':
-  dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module => '#{installed_path}/1.0',
-  dsc_resource_properties => {
+  resource_name => 'puppetfakeresource',
+  module => '#{installed_path}/1.0',
+  properties => {
     ensure          => 'present',
     importantstuff  => 'bar',
     throwmessage    => '#{throw_message_2}',

--- a/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
@@ -9,18 +9,18 @@ throw_message = SecureRandom.uuid
 
 dsc_manifest = <<-MANIFEST
 dsc { 'good_resource':
-  dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module => '#{installed_path}/1.0',
-  dsc_resource_properties => {
+  resource_name => 'puppetfakeresource',
+  module => '#{installed_path}/1.0',
+  properties => {
     ensure          => 'present',
     importantstuff  => 'foo',
   }
 }
 
 dsc { 'throw_resource':
-  dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module => '#{installed_path}/1.0',
-  dsc_resource_properties => {
+  resource_name => 'puppetfakeresource',
+  module => '#{installed_path}/1.0',
+  properties => {
     ensure          => 'present',
     importantstuff  => 'bar',
     throwmessage    => '#{throw_message}',

--- a/tests/acceptance/tests/basic_functionality/negative/dsc_on_linux.rb
+++ b/tests/acceptance/tests/basic_functionality/negative/dsc_on_linux.rb
@@ -12,9 +12,9 @@ test_file_contents = SecureRandom.uuid
 
 dsc_manifest = <<-MANIFEST
 dsc { '#{fake_name}':
-  dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module => '#{installed_path}/1.0',
-  dsc_resource_properties => {
+  resource_name => 'puppetfakeresource',
+  module => '#{installed_path}/1.0',
+  properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',
     destinationpath => 'C:\\#{fake_name}',

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
@@ -16,9 +16,9 @@ file { 'C:/#{ test_dir_path }' :
 }
 ->
 dsc { '#{fake_name}':
-  dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module => '#{installed_path}/1.0',
-  dsc_resource_properties => {
+  resource_name => 'puppetfakeresource',
+  module => '#{installed_path}/1.0',
+  properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',
     destinationpath => '#{"C:\\" + test_dir_path + "\\" + fake_name}',

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
@@ -15,9 +15,9 @@ file { 'C:/#{ test_dir_path }' :
 }
 ->
 dsc { '#{fake_name}':
-  dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module => '#{installed_path}/1.0',
-  dsc_resource_properties => {
+  resource_name => 'puppetfakeresource',
+  module => '#{installed_path}/1.0',
+  properties => {
     ensure          => 'present',
     importantstuff  => '#{SecureRandom.uuid}',
     destinationpath => '#{"C:\\" + test_dir_path + "\\" + fake_name}',

--- a/tests/acceptance/tests/dsc_type/custom_resource_from_system_PSModulePath.rb
+++ b/tests/acceptance/tests/dsc_type/custom_resource_from_system_PSModulePath.rb
@@ -12,10 +12,10 @@ fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
-  dsc_resource_name => 'PuppetFakeResource',
+  resource_name => 'PuppetFakeResource',
   # NOTE: relies on finding resource in system part of $ENV:PSModulePath
-  dsc_resource_module => 'PuppetFakeResource',
-  dsc_resource_properties => {
+  module => 'PuppetFakeResource',
+  properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',
     destinationpath => 'C:\\#{fake_name}'

--- a/tests/acceptance/tests/dsc_type/custom_resource_path.rb
+++ b/tests/acceptance/tests/dsc_type/custom_resource_path.rb
@@ -10,10 +10,10 @@ fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
-  dsc_resource_name => 'puppetfakeresource',
+  resource_name => 'puppetfakeresource',
   # NOTE: install_fake_reboot_resource installs on master, which pluginsyncs here
-  dsc_resource_module => '#{installed_path}/1.0',
-  dsc_resource_properties => {
+  module => '#{installed_path}/1.0',
+  properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',
     destinationpath => 'C:\\#{fake_name}'
@@ -50,9 +50,9 @@ end
 # New manifest to remove value.
 dsc_remove_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
-  dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module => '#{installed_path}/1.0',
-  dsc_resource_properties => {
+  resource_name => 'puppetfakeresource',
+  module => '#{installed_path}/1.0',
+  properties => {
     ensure          => 'absent',
     importantstuff  => '#{test_file_contents}',
     destinationpath => 'C:\\#{fake_name}'

--- a/tests/acceptance/tests/dsc_type/multiple_dsc_resources_in_PSModulePath.rb
+++ b/tests/acceptance/tests/dsc_type/multiple_dsc_resources_in_PSModulePath.rb
@@ -57,10 +57,10 @@ end
 test_file_contents = SecureRandom.uuid
 dsc_ambiguous_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
-  dsc_resource_name => 'PuppetFakeResource',
+  resource_name => 'PuppetFakeResource',
   # NOTE: relies on finding resource in system parts of $ENV:PSModulePath
-  dsc_resource_module => 'PuppetFakeResource',
-  dsc_resource_properties => {
+  module => 'PuppetFakeResource',
+  properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',
     destinationpath => 'C:\\#{fake_name}'
@@ -86,13 +86,13 @@ end
 # Test that DSC works with versioned reference
 dsc_versioned_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
-  dsc_resource_name => 'PuppetFakeResource',
+  resource_name => 'PuppetFakeResource',
   # NOTE: relies on finding resource in system parts of $ENV:PSModulePath
-  dsc_resource_module => {
+  module => {
     name    => 'PuppetFakeResource',
     version => '2.0',
   },
-  dsc_resource_properties => {
+  properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',
     destinationpath => 'C:\\#{fake_name}'

--- a/tests/acceptance/tests/dsc_type/psdesiredstateconfiguration.rb
+++ b/tests/acceptance/tests/dsc_type/psdesiredstateconfiguration.rb
@@ -8,9 +8,9 @@ fake_name = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
-  dsc_resource_name => 'file',
-  dsc_resource_module => 'PSDesiredStateConfiguration',
-  dsc_resource_properties => {
+  resource_name => 'file',
+  module => 'PSDesiredStateConfiguration',
+  properties => {
     ensure          => 'present',
     contents  => '#{test_file_contents}',
     destinationpath => 'C:\\#{fake_name}'
@@ -47,9 +47,9 @@ end
 # New manifest to remove value.
 dsc_remove_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
-  dsc_resource_name => 'file',
-  dsc_resource_module => 'PSDesiredStateConfiguration',
-  dsc_resource_properties => {
+  resource_name => 'file',
+  module => 'PSDesiredStateConfiguration',
+  properties => {
     ensure          => 'absent',
     contents  => '#{test_file_contents}',
     destinationpath => 'C:\\#{fake_name}'

--- a/tests/acceptance/tests/unicode/puppet_apply_utf8_file_name.rb
+++ b/tests/acceptance/tests/unicode/puppet_apply_utf8_file_name.rb
@@ -18,10 +18,10 @@ file_path = SecureRandom.uuid
 test_file_contents = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
 dsc {'some_name':
-  dsc_resource_name => 'puppetfakeresource',
+  resource_name => 'puppetfakeresource',
   # NOTE: install_fake_reboot_resource installs on master, which pluginsyncs here
-  dsc_resource_module => '#{installed_path}/1.0',
-  dsc_resource_properties => {
+  module => '#{installed_path}/1.0',
+  properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',
     destinationpath => 'C:\\#{file_path}\\#{file_name}'
@@ -61,9 +61,9 @@ end
 # New manifest to remove value.
 dsc_remove_manifest = <<-MANIFEST
 dsc {'some_name':
-  dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module => '#{installed_path}/1.0',
-  dsc_resource_properties => {
+  resource_name => 'puppetfakeresource',
+  module => '#{installed_path}/1.0',
+  properties => {
     ensure          => 'absent',
     importantstuff  => '#{test_file_contents}',
     destinationpath => 'C:\\#{file_path}\\#{file_name}'


### PR DESCRIPTION
Prior to this commit the dsc resource used the following long,
slightly repetitive names for the parameters:

- `dsc_resource_name`
- `dsc_resource_module`
- `dsc_resource_properties`

This commit replaces those names with the following:

- `resource_name`
- `module`
- `properties`