### PR TITLE
(MODULES-7179) Change created to invoked

### DIFF
--- a/lib/puppet/type/dsc.rb
+++ b/lib/puppet/type/dsc.rb
@@ -18,6 +18,16 @@ HERE
     # that the resource was created on runs where Invoke-DscResource _does_ modify the system.
     newvalue(:present) { provider.create }
     defaultto { :present }
+
+    def change_to_s(currentvalue, newvalue)
+      begin
+        if currentvalue == :absent || currentvalue.nil?
+          return _("invoked #{resource.parameters[:module].value}\\#{resource.parameters[:resource_name].value}")
+        else
+          super(currentvalue, newvalue)
+        end
+      end
+    end
   end
 
   newparam(:name, :namevar => true) do

--- a/spec/acceptance/basic_dsc_resources/failing_dsc_resources_spec.rb
+++ b/spec/acceptance/basic_dsc_resources/failing_dsc_resources_spec.rb
@@ -32,7 +32,7 @@ describe 'Negative resource tests' do
       it 'Applies manifest with one failing resource and one successful resource' do
         on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => 6) do |result|
           assert_match(error_msg, result.stderr, 'Expected error was not detected!')
-          assert_match(/Stage\[main\]\/Main\/Dsc\[good_resource\]\/ensure\: created/, result.stdout, 'DSC Resource missing!')
+          assert_match(/Stage\[main\]\/Main\/Dsc\[good_resource\]\/ensure\: invoked/, result.stdout, 'DSC Resource missing!')
         end
       end
     end

--- a/spec/acceptance/basic_functionality/puppet_apply_dsc_manifest_spec.rb
+++ b/spec/acceptance/basic_functionality/puppet_apply_dsc_manifest_spec.rb
@@ -45,7 +45,7 @@ describe 'Puppet apply tests' do
       it 'applies dsc_lite manifest via puppet apply' do
         on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
           assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-          assert_match(/Stage\[main\]\/Main\/Dsc\[#{fake_name}\]\/ensure\: created/, result.stdout, 'DSC Resource missing!')
+          assert_match(/Stage\[main\]\/Main\/Dsc\[#{fake_name}\]\/ensure\: invoked/, result.stdout, 'DSC Resource missing!')
         end
       end
 


### PR DESCRIPTION
This commit changes the message that Puppet returns when dsc_lite
resources are run from "created" to "invoked". This is because at the
moment, when we invoke a dsc_lite resource, Puppet does not know if the
resource we want to manage has actually been created, or if in reality
it has simply been modified, or even deleted. Changing to invoked is
more ambiguous, but accurately reflects the idea that we don't truly
know what operation dsc has accomplished for us.