### PR TITLE
(MODULES-6517) add --detailed-exitcodes 

### DIFF
--- a/spec/acceptance/basic_dsc_resources/failing_dsc_resources_spec.rb
+++ b/spec/acceptance/basic_dsc_resources/failing_dsc_resources_spec.rb
@@ -30,7 +30,7 @@ describe 'Negative resource tests' do
 
     windows_agents.each do |agent|
       it 'Applies manifest with one failing resource and one successful resource' do
-        on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 0) do |result|
+        on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => 6) do |result|
           assert_match(error_msg, result.stderr, 'Expected error was not detected!')
           assert_match(/Stage\[main\]\/Main\/Dsc\[good_resource\]\/ensure\: created/, result.stdout, 'DSC Resource missing!')
         end
@@ -69,7 +69,7 @@ describe 'Negative resource tests' do
 
     windows_agents.each do |agent|
       it 'Applies manifest with multiple failing resources' do
-        on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 0) do |result|
+        on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => 4) do |result|
           assert_match(error_msg_1, result.stderr, 'Expected error was not detected!')
           assert_match(error_msg_2, result.stderr, 'Expected error was not detected!')
         end

--- a/spec/acceptance/basic_functionality/negative/dsc_on_linux_spec.rb
+++ b/spec/acceptance/basic_functionality/negative/dsc_on_linux_spec.rb
@@ -17,7 +17,6 @@ describe 'FM-2623 - Attempt to Run DSC Manifest on a Linux Agent' do
     }
   MANIFEST
 
-# Verify
   error_msg = /Could not find a suitable provider for dsc/
 
 # NOTE: this test only runs when in a master / agent setup with more than Windows hosts
@@ -25,7 +24,7 @@ describe 'FM-2623 - Attempt to Run DSC Manifest on a Linux Agent' do
     confine_block(:except, :platform => 'windows') do
       agents.each do |agent|
         it 'Run Puppet Apply' do
-          on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => 4) do |result|
+          on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => 4) do |result|
             assert_match(error_msg, result.stderr, 'Expected error was not detected!')
           end
 
@@ -33,18 +32,6 @@ describe 'FM-2623 - Attempt to Run DSC Manifest on a Linux Agent' do
           on(agent, "test -f /cygdrive/c/#{fake_name}", :acceptable_exit_codes => [1])
         end
       end
-    end
-  end
-
-  before(:all) do
-    agents.each do |agent|
-      setup_dsc_resource_fixture(agent)
-    end
-  end
-
-  after(:all) do
-    agents.each do |agent|
-      teardown_dsc_resource_fixture(agent)
     end
   end
 end

--- a/spec/acceptance/basic_functionality/puppet_apply_dsc_manifest_spec.rb
+++ b/spec/acceptance/basic_functionality/puppet_apply_dsc_manifest_spec.rb
@@ -43,7 +43,7 @@ describe 'Puppet apply tests' do
   context 'FM-2625 - Apply DSC Resource Manifest via "puppet apply"' do
     windows_agents.each do |agent|
       it 'applies dsc_lite manifest via puppet apply' do
-        on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
+        on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
           assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
           assert_match(/Stage\[main\]\/Main\/Dsc\[#{fake_name}\]\/ensure\: created/, result.stdout, 'DSC Resource missing!')
         end
@@ -61,7 +61,7 @@ describe 'Puppet apply tests' do
   context 'FM-2623 - Apply DSC Resource Manifest in "noop" Mode Using "puppet apply"' do
     windows_agents.each do |agent|
       it 'Applies noop manifest' do
-        on(agent, puppet('apply --noop'), :stdin => dsc_manifest_2, :acceptable_exit_codes => [0, 2]) do |result|
+        on(agent, puppet('apply --noop --detailed-exitcodes'), :stdin => dsc_manifest_2, :acceptable_exit_codes => [0, 2]) do |result|
           assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
         end
       end

--- a/spec/acceptance/dsc_type/custom_resource_from_system_PSModulePath_spec.rb
+++ b/spec/acceptance/dsc_type/custom_resource_from_system_PSModulePath_spec.rb
@@ -24,7 +24,7 @@ describe 'Custom resource from system path' do
   context 'Loads a custom DSC resource from system PSModulePath by ModuleName' do
     windows_agents.each do |agent|
       it 'Run Puppet Apply' do
-        on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
+        on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
           assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
         end
       end

--- a/spec/acceptance/dsc_type/custom_resource_path_spec.rb
+++ b/spec/acceptance/dsc_type/custom_resource_path_spec.rb
@@ -32,7 +32,7 @@ describe 'Custom resource from path' do
   context 'Apply generic DSC Manifest to create a puppetfakeresource' do
   windows_agents.each do |agent|
     it 'Run Puppet Apply' do
-      on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
+      on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
         assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
       end
     end
@@ -48,7 +48,7 @@ describe 'Custom resource from path' do
 
   windows_agents.each do |agent|
     it 'Apply Manifest to Remove File' do
-      on(agent, puppet('apply'), :stdin => dsc_remove_manifest, :acceptable_exit_codes => [0, 2]) do |result|
+      on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_remove_manifest, :acceptable_exit_codes => [0, 2]) do |result|
         assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
       end
     end

--- a/spec/acceptance/dsc_type/multiple_dsc_resources_in_PSModulePath_spec.rb
+++ b/spec/acceptance/dsc_type/multiple_dsc_resources_in_PSModulePath_spec.rb
@@ -44,7 +44,7 @@ describe 'Multiple versioned resource tests' do
     windows_agents.each do |agent|
       it 'Run Puppet Apply' do
         # this scenario fails as DSC doesn't know which version to use
-        on(agent, puppet('apply'), :stdin => dsc_ambiguous_manifest, :acceptable_exit_codes => [0, 2, 4]) do |result|
+        on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_ambiguous_manifest, :acceptable_exit_codes => [0, 2, 4]) do |result|
           # NOTE: regex includes Node\[default\]\/ when run via agent rather than apply
           error_msg = /Stage\[main\]\/Main\/Dsc\[#{fake_name}\]\: Could not evaluate\: Resource PuppetFakeResource was not found\./
           assert_match(error_msg, result.stderr, 'Expected Invoke-DscResource error missing!')
@@ -61,7 +61,7 @@ describe 'Multiple versioned resource tests' do
   context 'Can load DSC Resource from PSModulePath by ModuleName when version specified' do
     windows_agents.each do |agent|
       it 'Run Puppet Apply' do
-        on(agent, puppet('apply'), :stdin => dsc_versioned_manifest, :acceptable_exit_codes => [0]) do |result|
+        on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_versioned_manifest, :acceptable_exit_codes => [2]) do |result|
           assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
         end
       end

--- a/spec/acceptance/dsc_type/psdesiredstateconfiguration_spec.rb
+++ b/spec/acceptance/dsc_type/psdesiredstateconfiguration_spec.rb
@@ -31,7 +31,7 @@ describe 'Puppet apply for file resource ensure present and ensure absent' do
   context 'Apply generic DSC Manifest to create a standard DSC File' do
     windows_agents.each do |agent|
       it 'Run puppet apply to create file' do
-        on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
+        on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
           assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
         end
       end
@@ -47,7 +47,7 @@ describe 'Puppet apply for file resource ensure present and ensure absent' do
   context 'Apply generic DSC Manifest to remove a standard DSC File' do
     windows_agents.each do |agent|
       it 'Applies manifest to remove file' do
-        on(agent, puppet('apply'), :stdin => dsc_remove_manifest, :acceptable_exit_codes => [0, 2]) do |result|
+        on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_remove_manifest, :acceptable_exit_codes => [0, 2]) do |result|
           assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
         end
       end

--- a/spec/acceptance/reboot/negative/reboot_graph_cycle_spec.rb
+++ b/spec/acceptance/reboot/negative/reboot_graph_cycle_spec.rb
@@ -18,7 +18,7 @@ describe 'Reboot - Negative Tests' do
     context 'MODULES-2843 - Attempt to Apply DSC Resource that Requires Reboot with Inverse Relationship to a "reboot" Resource' do
       windows_agents.each do |agent|
         it 'Run Puppet Apply' do
-          on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 1]) do |result|
+          on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 1]) do |result|
             assert_match(error_message, result.stderr, 'Expected error was not detected!')
           end
         end

--- a/spec/acceptance/reboot/reboot_autonotify_explicit_spec.rb
+++ b/spec/acceptance/reboot/reboot_autonotify_explicit_spec.rb
@@ -6,9 +6,9 @@ describe 'Reboot tests: Autonotify, Explicit' do
     context 'MODULES-2843 - Apply DSC Resource that Requires Reboot with Autonotify "reboot" Resource' do
       dsc_manifest = <<-MANIFEST
     dsc { 'reboot_test':
-      dsc_resource_name => 'puppetfakeresource',
-      dsc_resource_module => '#{installed_path}/1.0',
-      dsc_resource_properties => {
+      resource_name => 'puppetfakeresource',
+      module => '#{installed_path}/1.0',
+      properties => {
         importantstuff  => 'reboot',
         requirereboot   => true,
       }
@@ -20,7 +20,7 @@ describe 'Reboot tests: Autonotify, Explicit' do
 
       windows_agents.each do |agent|
         it 'Run Puppet Apply' do
-          on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
+          on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
             assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
             assert_no_match(/Warning:/, result.stderr, 'Unexpected warning was detected!')
           end
@@ -53,7 +53,7 @@ describe 'Reboot tests: Autonotify, Explicit' do
 
       windows_agents.each do |agent|
         it 'Run Puppet Apply' do
-          on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
+          on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
             assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
             assert_no_match(/Warning:/, result.stderr, 'Unexpected warning was detected!')
           end

--- a/spec/acceptance/reboot/reboot_no_invoke_warning_spec.rb
+++ b/spec/acceptance/reboot/reboot_no_invoke_warning_spec.rb
@@ -8,9 +8,9 @@ describe 'Reboot tests: No Invoke, Warning' do
       test_file_contents = SecureRandom.uuid
       dsc_manifest = <<-MANIFEST
       dsc { '#{fake_name}':
-        dsc_resource_name       => 'puppetfakeresource',
-        dsc_resource_module     => '#{installed_path}/1.0',
-        dsc_resource_properties => {
+        resource_name       => 'puppetfakeresource',
+        module     => '#{installed_path}/1.0',
+        properties => {
           ensure          => present,
           importantstuff  => '#{test_file_contents}',
           destinationpath => 'C:\\#{fake_name}',
@@ -28,7 +28,7 @@ describe 'Reboot tests: No Invoke, Warning' do
         end
 
         it 'Run Puppet Apply' do
-          on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
+          on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
             # NOTE: regex includes Node\[default\]\/ when run via agent rather than apply
             assert_match(/Stage\[main\]\/Main\/Dsc\[#{fake_name}\]\/ensure\: created/, result.stdout, 'DSC Resource missing!')
             assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
@@ -54,9 +54,9 @@ describe 'Reboot tests: No Invoke, Warning' do
       installed_path = get_dsc_resource_fixture_path(usage = :manifest)
       dsc_manifest = <<-MANIFEST
       dsc { 'reboot_test':
-        dsc_resource_name => 'puppetfakeresource',
-        dsc_resource_module => '#{installed_path}/1.0',
-        dsc_resource_properties => {
+        dresource_name => 'puppetfakeresource',
+        module => '#{installed_path}/1.0',
+        properties => {
           importantstuff  => 'reboot',
           requirereboot   => true,
         }
@@ -67,7 +67,7 @@ describe 'Reboot tests: No Invoke, Warning' do
 
       windows_agents.each do |agent|
         it 'Run Puppet Apply' do
-          on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
+          on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
             assert_match(warning_message, result.stderr, 'Expected warning was not detected!')
             assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
           end

--- a/spec/acceptance/unicode/puppet_apply_utf8_file_name_spec.rb
+++ b/spec/acceptance/unicode/puppet_apply_utf8_file_name_spec.rb
@@ -41,7 +41,7 @@ describe 'UTF-8 tests' do
   context 'Apply generic DSC Manifest with ensure present on UTF-8 file name to create a puppetfakeresource' do
     windows_agents.each do |agent|
       it 'Run Puppet Apply' do
-        on(agent, puppet('apply'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
+        on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_manifest, :acceptable_exit_codes => [0, 2]) do |result|
           assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
         end
       end
@@ -58,7 +58,7 @@ describe 'UTF-8 tests' do
   context 'Apply generic DSC Manifest with ensure absent on UTF-8 file name to remove a puppetfakeresource' do
     windows_agents.each do |agent|
       it 'Apply Manifest to Remove File' do
-        on(agent, puppet('apply'), :stdin => dsc_remove_manifest, :acceptable_exit_codes => [0, 2]) do |result|
+        on(agent, puppet('apply --detailed-exitcodes'), :stdin => dsc_remove_manifest, :acceptable_exit_codes => [0, 2]) do |result|
           assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
         end
       end

--- a/spec/lib/dsc_utils.rb
+++ b/spec/lib/dsc_utils.rb
@@ -93,15 +93,11 @@ def setup_dsc_resource_fixture(host)
 end
 
 def get_dsc_resource_fixture_path(usage = :manifest)
-  # Master or masterless determine content locations
-  is_pluginsync = hosts.any? { |h| h['roles'].include?('master') }
-
   install_root = usage == :manifest ? 'C:/' : '/cygdrive/c'
 
-  install_base = "#{install_root}/ProgramData/PuppetLabs/" +
-    (is_pluginsync ? 'puppet/cache' : 'code/modules/dsc_lite')
+  install_base = "#{install_root}/ProgramData/PuppetLabs/code/modules/dsc_lite"
 
-  installed_path = "#{install_base}/lib/puppet_x/dsc_resources/PuppetFakeResource"
+  return "#{install_base}/lib/puppet_x/dsc_resources/PuppetFakeResource"
 end
 
 # Remove the "PuppetFakeResource" module on target host.


### PR DESCRIPTION
Modified the currently non-running reboot tests to reflect dsc_ prefix name change

Modified dsc_util to look for the same module path in both agnet and master/agent runs

Added "--detailed-exitcodes" to make puppet calls look like "puppet(apply --detailed-exitcodes)" so that we can detect the correct exit codes.