### PR TITLE
(MODULES-7437) Use absolute link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ To express EmbeddedInstances, the `properties` parameter will recognize any key 
 
 ## Limitations
 
-- For a list of tradeoffs and improvements in the dsc_lite module compared to the dsc module, see [README_Tradeoffs.md](README_Tradeoffs.md)
+- For a list of tradeoffs and improvements in the dsc_lite module compared to the dsc module, see [README_Tradeoffs.md](https://github.com/puppetlabs/puppetlabs-dsc_lite/blob/master/README_Tradeoffs.md)
 
 - DSC Composite Resources are not supported.
 


### PR DESCRIPTION
Previously the trade offs link was relative to the README, however, on the Forge this does not work.  This commit updates the link to be absolute.