### PR TITLE
(MODULES-7178) Report types dynamically

### DIFF
--- a/lib/puppet/provider/base_dsc_lite/powershell.rb
+++ b/lib/puppet/provider/base_dsc_lite/powershell.rb
@@ -169,7 +169,7 @@ EOT
   def self.ps_script_content(mode, resource, provider)
     dsc_invoke_method = mode
     @param_hash = resource
-    template_name = resource.type == :dsc ?
+    template_name = resource.generic_dsc ?
       '/invoke_generic_dsc_resource.ps1.erb' :
       '/invoke_dsc_resource.ps1.erb'
     file = File.new(template_path + template_name, :encoding => Encoding::UTF_8)

--- a/lib/puppet/type/dsc.rb
+++ b/lib/puppet/type/dsc.rb
@@ -4,6 +4,20 @@ Puppet::Type.newtype(:dsc) do
   require Pathname.new(__FILE__).dirname + '../../' + 'puppet/type/base_dsc_lite'
   require Pathname.new(__FILE__).dirname + '../../puppet_x/puppetlabs/dsc_lite/dsc_type_helpers'
 
+  def type
+    # in the event this value is consumed early in the lifecycle / before
+    # parameters have been populated, use 'unspecified'
+    name = ( parameters[:resource_name].nil? || parameters[:resource_name].value.nil? || (parameters[:resource_name].value =~ /\W/) ) ?
+      'unspecified' :
+      # but for the sake of catalog eval / report status, masquerade as a different type
+      parameters[:resource_name].value.downcase
+    "Dsc_lite_#{name}".to_sym
+  end
+
+  def generic_dsc
+    true
+  end
+
   ensurable do
     desc <<-HERE
     An optional property that specifies that the DSC resource should be invoked.

--- a/spec/unit/puppet/type/dsc_spec.rb
+++ b/spec/unit/puppet/type/dsc_spec.rb
@@ -8,6 +8,22 @@ describe Puppet::Type.type(:dsc) do
 
   it { is_expected.to be_a_kind_of Puppet::Type::Dsc }
 
+  describe "type" do
+    it "should be built dynamically from parameter :resource_name" do
+      resource[:resource_name] = 'foo'
+      expect(resource.type).to eq(:Dsc_lite_foo)
+    end
+
+    it "should return Dsc_lite_unspecified given a missing :resource_name" do
+      expect(resource.type).to eq(:Dsc_lite_unspecified)
+    end
+
+    it "should return Dsc_lite_unspecified given a :resource_name of ' '" do
+      resource[:resource_name] = ' '
+      expect(resource.type).to eq(:Dsc_lite_unspecified)
+    end
+  end
+
   describe "parameter :name" do
     subject { resource.parameters[:name] }
 


### PR DESCRIPTION
 - [x] ~Determine if new tests can / should be added~ basic specs added
 - [x] ~~Should `resource_name` be canonicalized? i.e. Does `FiLe` show up differently than `file`... do we care? (Report logic already calls `capitalize` and the report looks fine, but should the internal tracking maintain state differently?)~~ Canonicalized by calling `downcase` on the `resource_name` property so that case differences don't matter internally.
 - [x] Make sure nothing else weird happens in the system when the type reports as `:dsc_foo` instead of `:dsc`. ~~Are there any other dependencies on the symbol `:dsc`?~~ There are no other usages of `:dsc`
 - [x] ~~Make sure that behavior on an older PE install is reasonable (without the PUP-8746 / https://github.com/puppetlabs/puppet/commit/28240e5e300e8548be33142e108cf706a788bd74 fix) - it may end up behaving partially correctly if metrics summary is out of sync with actual resource types~~ Screenshots / explanation below. Behavior is OK and as expected.
 - [x] ~~Test in conjunction with the DSC resource that may refer to the same types (should we use `DscLite_` instead of `Dsc_` for the prefix?)~~ Vetted this with @michaeltlombardi - didn't include screenshots, but it was necessary to prefix with `dsc_lite_` to avoid collisions with DSC module

- Prior to this commit, all types would report the `dsc` type as their
   identity. This is problematic for the sake of reporting as every type
   of resource is grouped together under `dsc`, rather than the specific
   `resource_name` modeled in a manifest.

   This new approach allows for types to report under something more
   useful that indicates the original DSC resource type specified in the
   resource_name attribute.

   For instance, given a manifest with the following resources:

```puppet
   dsc { 'sample_file':
     resource_name     => 'File',
     module            => 'PSDesiredStateConfiguration',
     properties        => {
       ensure          => 'present',
       contents        => 'hello',
       destinationpath => 'c:\\test.txt',
     }
  }

  dsc { 'lmhosts':
     resource_name     => 'Service',
     module            => 'PSDesiredStateConfiguration',
     properties        => {
       name            => 'lmhosts',
       ensure          => 'present',
       state           => 'running',
     }
  }
```

  The report now shows:

  * Dsc_lite_file[sample_file]    Unchanged
  * Dsc_lite_service[lmhosts]     Unchanged

  Instead of what it previously reported:

  * Dsc[sample_file]              Unchanged
  * Dsc[lmhosts]                  Unchanged

 - Selection of the PowerShell code was previously determined by type,
   but given it has changed to being specified as :Dsc_lite_XXXX, its
   not as easy to do that anymore. Instead, add a simple boolean
   property to the generic dsc wrapper that may be checked instead.

 - Note that parameter validation for `module`, `resource_name` and
   properties does not currently work, but will be fixed in another
   ticket by adding a global validator. The `type` method performs some
   additional guarding around usage of the `resource_name` parameter
   for 2 reasons:

   * It's unclear if the parser or other logic in Puppet uses the type
     name without the resource being instantiated fully with values from
     a manifest
   * Due to the incorrect validation, the PE console errors with the
     following message when `resource_name` is left unspecified:

   undefined method `value` for nil:NilClass