### PR TITLE
(MODULES-7554) Fix crash on Puppet 4 / WMF < 5

### DIFF
--- a/lib/puppet/feature/dsc_lite.rb
+++ b/lib/puppet/feature/dsc_lite.rb
@@ -18,14 +18,18 @@ if Puppet.features.microsoft_windows?
   if (installed_version >= required_version)
     Puppet.features.add(:dsc_lite)
   else
-    Puppet.warn_once(
+    params = [
       'dsc_lite_unavailable',
       :dsc_lite_unavailable,
       DSC_LITE_MODULE_POWERSHELL_UPGRADE_MSG %
         { :required => required_version, :current => installed_version},
       nil,
-      nil,
-      :err
-    )
+      nil
+    ]
+
+    # Puppet 5 allows changing warning to error
+    params << :err if Puppet.method(:warn_once).arity > 5
+
+    Puppet.warn_once(*params)
   end
 end


### PR DESCRIPTION
 - 914d934651a68efd2f107f2ed5e36f5449929b5a introduced a new feature for
   dsc_lite. In situations where the proper WMF5 version was not
   available, a warning would be generated using the Puppet.warn_once
   helper.

   However, it was not realized that Puppet 4 and Puppet 5 have
   different numbers of arguments that can be passed to warn_once, and
   that only Puppet 5 supported changing warning to error.

   That change was introduced in
   https://github.com/puppetlabs/puppet/commit/3d823370884f032368d118e045af86bf54386a63

 - Calling a Ruby method with too many arguments causes a Ruby crash and
   results in a completely terminated Puppet run that produces no report
   for the master. In other words, this is a completely catastrophic
   failure case.

 - Resolve this problem by checking the arity of the Puppet.warn_once
   call to send the right number of arguments on Puppet 4.

   The concession was made to vary the message type on Puppet 4 (warning)
   vs Puppet 5 (error), because the alternative solution did not
   preserve the warn_once style behavior. Instead, it would have
   produced an error for every single dsc_lite resource, which was far
   less desirable.