### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,22 @@ See [known issues](#known-issues) for troubleshooting setup.
 
 ## Usage
 
-The generic `dsc` type is a streamlined and minimal representation of a DSC Resource declaration in Puppet syntax. You can use a DSC Resource by supplying the same properties you would set in a DSC Configuration script, inside the `properties` parameter. For most use cases, the `properties` parameter accepts the same structure as the PowerShell syntax, with the substitution of Puppet syntax for arrays, hashes, and other data structures.
+The generic `dsc` type is a streamlined and minimal representation of a DSC Resource declaration in Puppet syntax. You can use a DSC Resource by supplying the same properties you would set in a DSC Configuration script, inside the `properties` parameter. For most use cases, the `properties` parameter accepts the same structure as the PowerShell syntax, with the substitution of Puppet syntax for arrays, hashes, and other data structures. You can use PowerShell on the command-line to identify the available parameters.
 
-A DSC resource specified in PowerShell:
+~~~powershell
+PS C:\> (Get-DscResource -name xADDomain).Properties
+ 
+Name                          PropertyType                                    IsMandatory Values
+----                          ------------                                    ----------- ------
+DomainAdministratorCredential [PSCredential]                                         True {}
+DomainName                    [string]                                               True {}
+SafemodeAdministratorPassword [PSCredential]                                         True {}
+DependsOn                     [string[]]                                            False {}
+DnsDelegationCredential       [PSCredential]                                        False {}
+ParentDomainName              [string]                                              False {}
+~~~
+
+An example of that DSC resource specified in PowerShell:
 
 ~~~powershell
 WindowsFeature IIS {


### PR DESCRIPTION
With native Puppet types (including the `dsc_*` types), we're used to being able use `puppet describe` to explore the types and discover available parameters. When porting from `dsc` to `dsc_lite`, the lack of that ability might be a sticking point, especially for admins who primarily administer Linux boxes and aren't comfortable enough with PowerShell to know how to do this on their own.

To mitigate that, we'll just show an example in the REAME.

(Can someone with an actual Windows box correct this example to be consistent with the `WindowsFeature` code snippets that follow?)