### PR TITLE
(MODULES-8175) Add safety to new-pscredential helper

### DIFF
--- a/lib/puppet/provider/base_dsc_lite/invoke_dsc_resource.ps1.erb
+++ b/lib/puppet/provider/base_dsc_lite/invoke_dsc_resource.ps1.erb
@@ -12,9 +12,27 @@ function new-pscredential
 
     [parameter(Mandatory=$true,
       ValueFromPipelineByPropertyName=$true)]
-    [string]
+    [object]
     $password
   )
+
+  Switch ($password.GetType().FullName) {
+    'System.String' {
+      [string]$password = $password
+    }
+
+    'System.Collections.Hashtable' {
+      If ($password.__pcore_type__ -eq 'Sensitive') {
+        [string]$password = $password.__pcore_value__
+      } ElseIf ($password.__ptype -eq 'Sensitive') {
+        [string]$password = $password.__pvalue
+      } Else { Throw "An invalid object was passed as a password: $password" }
+    }
+
+    default {
+      Throw "An invalid object was passed instead of a password: Object type was [$($password.GetType().FullName)] and value was $password"
+    }
+  }
 
   $secpasswd   = ConvertTo-SecureString $password -AsPlainText -Force
   $credentials = New-Object System.Management.Automation.PSCredential ($user, $secpasswd)
@@ -27,44 +45,43 @@ $response = @{
   errormessage   = ''
 }
 
-$invokeParams = @{
-  Name          = '<%= resource.dscmeta_resource_friendly_name %>'
-  Method        = '<%= dsc_invoke_method %>'
-  Property      = @{
-<% provider.dsc_parameters.each do |p| -%>
-    <%- name = p.name.to_s.gsub(/^dsc_/,'')
-    if name == 'ensure' && dsc_invoke_method == 'test'
-      value = "\'#{resource.parameters[:ensure].default.to_s}\'"
-    elsif p.mof_type == 'MSFT_Credential'
-      value = "[PSCustomObject]#{format_dsc_value(p.value)} | new-pscredential"
-    elsif p.mof_is_embedded? && p.mof_type != 'MSFT_KeyValuePair'
-      vals = p.value.is_a?(Hash) ? [p.value] : p.value
-      vals = vals.collect do |v|
-        "(New-CimInstance -ClassName '#{p.mof_type.gsub('[]','')}' -ClientOnly -Property #{format_dsc_value(v)})"
-      end
-      # Ensure that we pass a single CimInstance or array correctly based on MOF schema definition
-      if p.value.is_a?(Hash)
-        value = "[CimInstance]#{vals.first}"
-      else
-        value = "[CimInstance[]]@(#{vals.join(',')})"
-      end
-    else
-      value = format_dsc_value(p.value)
-    end
-    -%>
-    <%= name %> = <%= value %>
-<% end -%>
-  }<% if resource.respond_to?(:dscmeta_module_version) %>
-  ModuleName = @{
-    ModuleName      = <%= "\"#{vendored_modules_path}/#{resource.dscmeta_module_name}/#{resource.dscmeta_module_name}.psd1\"" %>
-    RequiredVersion = <%= "\"#{resource.dscmeta_module_version}\"" %>
-  }
-<% else %>
-  ModuleName = <%= "\"#{resource.dscmeta_module_name}\"" %>
-<% end -%>
-}
-
 try{
+    $invokeParams = @{
+      Name          = '<%= resource.dscmeta_resource_friendly_name %>'
+      Method        = '<%= dsc_invoke_method %>'
+      Property      = @{
+    <% provider.dsc_parameters.each do |p| -%>
+        <%- name = p.name.to_s.gsub(/^dsc_/,'')
+        if name == 'ensure' && dsc_invoke_method == 'test'
+          value = "\'#{resource.parameters[:ensure].default.to_s}\'"
+        elsif p.mof_type == 'MSFT_Credential'
+          value = "[PSCustomObject]#{format_dsc_value(p.value)} | new-pscredential"
+        elsif p.mof_is_embedded? && p.mof_type != 'MSFT_KeyValuePair'
+          vals = p.value.is_a?(Hash) ? [p.value] : p.value
+          vals = vals.collect do |v|
+            "(New-CimInstance -ClassName '#{p.mof_type.gsub('[]','')}' -ClientOnly -Property #{format_dsc_value(v)})"
+          end
+          # Ensure that we pass a single CimInstance or array correctly based on MOF schema definition
+          if p.value.is_a?(Hash)
+            value = "[CimInstance]#{vals.first}"
+          else
+            value = "[CimInstance[]]@(#{vals.join(',')})"
+          end
+        else
+          value = format_dsc_value(p.value)
+        end
+        -%>
+        <%= name %> = <%= value %>
+    <% end -%>
+      }<% if resource.respond_to?(:dscmeta_module_version) %>
+      ModuleName = @{
+        ModuleName      = <%= "\"#{vendored_modules_path}/#{resource.dscmeta_module_name}/#{resource.dscmeta_module_name}.psd1\"" %>
+        RequiredVersion = <%= "\"#{resource.dscmeta_module_version}\"" %>
+      }
+    <% else %>
+      ModuleName = <%= "\"#{resource.dscmeta_module_name}\"" %>
+    <% end -%>
+    }
     $result = Invoke-DscResource @invokeParams
 }catch{
   $response.errormessage   = $_.Exception.Message

--- a/lib/puppet/provider/base_dsc_lite/invoke_generic_dsc_resource.ps1.erb
+++ b/lib/puppet/provider/base_dsc_lite/invoke_generic_dsc_resource.ps1.erb
@@ -7,8 +7,26 @@ function new-pscredential{
     [parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
     [string]$user,
     [parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
-    [string]$password
+    [object]$password
   )
+
+  Switch ($password.GetType().FullName) {
+    'System.String' {
+      [string]$password = $password
+    }
+
+    'System.Collections.Hashtable' {
+      If ($password.__pcore_type__ -eq 'Sensitive') {
+        [string]$password = $password.__pcore_value__
+      } ElseIf ($password.__ptype -eq 'Sensitive') {
+        [string]$password = $password.__pvalue
+      } Else { Throw "An invalid object was passed as a password: $password" }
+    }
+
+    default {
+      Throw "An invalid object was passed instead of a password: Object type was [$($password.GetType().FullName)] and value was $password"
+    }
+  }
 
   $secpasswd   = ConvertTo-SecureString $password -AsPlainText -Force
   $credentials = New-Object System.Management.Automation.PSCredential ($user, $secpasswd)
@@ -21,23 +39,22 @@ $response = @{
   errormessage   = ''
 }
 
-$invokeParams = @{
-Name       = '<%= resource.parameters[:resource_name].value %>'
-ModuleName = <% if resource.parameters[:module].value.is_a?(Hash) -%>
-@{
-modulename    = '<%= resource.parameters[:module].value['name'] %>'
-moduleversion = '<%= resource.parameters[:module].value['version'] %>'
-}
-<% else -%>
-'<%= resource.parameters[:module].value %>'
-<% end -%>
-Method     = '<%= dsc_invoke_method %>'
-Property   = <% provider.dsc_property_param.each do |p| -%>
-<%= format_dsc_lite(p.value) %>
-<% end -%>
-}
-
 try{
+  $invokeParams = @{
+    Name       = '<%= resource.parameters[:resource_name].value %>'
+    ModuleName = <% if resource.parameters[:module].value.is_a?(Hash) -%>
+    @{
+    modulename    = '<%= resource.parameters[:module].value['name'] %>'
+    moduleversion = '<%= resource.parameters[:module].value['version'] %>'
+    }
+    <% else -%>
+    '<%= resource.parameters[:module].value %>'
+    <% end -%>
+    Method     = '<%= dsc_invoke_method %>'
+    Property   = <% provider.dsc_property_param.each do |p| -%>
+    <%= format_dsc_lite(p.value) %>
+    <% end -%>
+  }
   $result = Invoke-DscResource @invokeParams
 }catch{
   $response.errormessage = $_.Exception.Message


### PR DESCRIPTION
Prior to this commit the helper function `new-pscredential`
in the template used to invoke DSC resources attempted to
cast an incoming value for password to a string. When passed
a hashtable, it was unable to extract the password for use
and instead set the password as the typename for the object.

This happened when the catalog was compiled on a Puppet 5
master to apply to a Puppet 6 agent or when compiled on a
Puppet 6 master for a Puppet 5 agent and specifying the
password using the sensitive datatype.

This problem was introduced in MODULES-8597 when the tags
for rich data serialization were changed from `__pcore_type_`
and `__pcore_value__` to the shorter `__ptype` and `__pvalue`.
After this change, the master and agent both expect different
keys for the sensitive data type, which is why this problem
only shows when the master and agent are mismatched versions.

This commit modifies the `new-pscredential` helper function
to include handling for both strings and hashtables, and
will extract the password if possible and error loudly if
not.