### PR TITLE
(MODULES-8175) Munge Properties Hash for Sensitive

### DIFF
--- a/lib/puppet/type/dsc.rb
+++ b/lib/puppet/type/dsc.rb
@@ -87,6 +87,10 @@ HERE
       end
       fail "#{self.name.to_s} should be a Hash" unless value.is_a? ::Hash
     end
+
+    munge do |value|
+      PuppetX::DscLite::TypeHelpers.munge_sensitive_hash(value)
+    end
   end
 
   validate do

--- a/lib/puppet_x/puppetlabs/dsc_lite/dsc_type_helpers.rb
+++ b/lib/puppet_x/puppetlabs/dsc_lite/dsc_type_helpers.rb
@@ -8,6 +8,21 @@ module PuppetX
         raise ArgumentError.new "invalid value: #{value}"
       end
 
+      # This is used to recursively search the hash to find sensitive data
+      # and ensure it is properly represented.
+      # It will modify the values in the hash passed to it.
+      def self.munge_sensitive_hash(h)
+        if h.is_a?(Hash) && h['__pcore_type__'] == 'Sensitive' && h.key?('__pcore_value__')
+          return Puppet::Pops::Types::PSensitiveType::Sensitive.new(h['__pcore_value__'])
+        elsif h.is_a?(Hash) && h['__ptype'] == 'Sensitive' && h.key?('__pvalue')
+          return Puppet::Pops::Types::PSensitiveType::Sensitive.new(h['__pvalue'])
+        else
+          h.each_pair do |key, value|      
+            h[key] = munge_sensitive_hash(value) if value.is_a?(Hash)
+          end
+        end
+      end
+
       def self.munge_integer(value)
         value.is_a?(Array) ? value.map { |v| v.to_i } : value.to_i
       end


### PR DESCRIPTION
Prior to this commit the PowerShell template code included a workaround
which munged a malformed hash (which should have been a sensitive value)
in the `New-PSCredential` method.

This commit adds a deserialization method and uses it in the munging
of the properties hash itself, obviating the need to handle this in
the PowerShell template code.

This also handles sensitive values for things other than the
MSFT_Credential DSC type, which the prior implementation did not.