### PR TITLE
(MODULES-7716) Fix Readme Reboot Snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,8 @@ Add the following `reboot` resource to your manifest. It must have the name `dsc
 ~~~puppet
 reboot { 'dsc_reboot' :
   message => 'DSC has requested a reboot',
-  when    => 'pending'
+  when    => 'pending',
+  onlyif  => 'pending_dsc_reboot',
 }
 ~~~
 


### PR DESCRIPTION
A customer reported to us that the snippet in the readme for handling
reboots was not correct, and would result in un wanted reboots on
nodes. This change ensures that only reboots requested by this module
are executed.