### PR TITLE
(MODULES-8856) Redact debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Fixed
+- Ensure sensitive values are redacted in debug output ([MODULES-8856](https://tickets.puppetlabs.com/browse/MODULES-8856))
+
 ## 2019-02-07
 ### Summary
 Release fixes sensitive data types to function when master and agent are different major versions of Puppet.

--- a/lib/puppet/provider/base_dsc_lite/powershell.rb
+++ b/lib/puppet/provider/base_dsc_lite/powershell.rb
@@ -77,7 +77,7 @@ EOT
     version = Facter.value(:powershell_version)
     Puppet.debug "PowerShell Version: #{version}"
     script_content = ps_script_content('test')
-    Puppet.debug "\n" + script_content
+    Puppet.debug "\n" + self.class.redact_content(script_content)
 
     if !PuppetX::DscLite::PowerShellManager.supported?
       self.class.upgrade_message
@@ -97,7 +97,7 @@ EOT
 
   def create
     script_content = ps_script_content('set')
-    Puppet.debug "\n" + script_content
+    Puppet.debug "\n" + self.class.redact_content(script_content)
 
     if !PuppetX::DscLite::PowerShellManager.supported?
       self.class.upgrade_message
@@ -148,7 +148,7 @@ EOT
     when dsc_value.class.name == 'Hash'
       "@{" + dsc_value.collect{|k, v| format_dsc_value(k) + ' = ' + format_dsc_value(v)}.join('; ') + "}"
     when dsc_value.class.name == 'Puppet::Pops::Types::PSensitiveType::Sensitive'
-      "'#{escape_quotes(dsc_value.unwrap)}'"
+      "'#{escape_quotes(dsc_value.unwrap)}' # PuppetSensitive"
     else
       fail "unsupported type #{dsc_value.class} of value '#{dsc_value}'"
     end
@@ -160,6 +160,16 @@ EOT
 
   def self.escape_quotes(text)
     text.gsub("'", "''")
+  end
+
+  def self.redact_content(content)
+    # Note that here we match after an equals to ensure we redact the value being passed, but not the key.
+    # This means a redaction of a string not including '= ' before the string value will not redact.
+    # Every secret unwrapped in this module will unwrap as "'secret' # PuppetSensitive" and, currently,
+    # always inside a hash table to be passed along. This means we can (currently) expect the value to
+    # always come after an equals sign.
+    # Note that the line may include a semi-colon and/or a newline character after the sensitive unwrap.
+    content.gsub(/= '.+' # PuppetSensitive;?(\\n)?$/,"= '[REDACTED]'")
   end
 
   def ps_script_content(mode)

--- a/lib/puppet_x/puppetlabs/dsc_lite/powershell_hash_formatter.rb
+++ b/lib/puppet_x/puppetlabs/dsc_lite/powershell_hash_formatter.rb
@@ -18,7 +18,7 @@ module PuppetX
           when dsc_value.class.name == 'Hash'
             self.format_hash(dsc_value)
           when dsc_value.class.name == 'Puppet::Pops::Types::PSensitiveType::Sensitive'
-            "'#{escape_quotes(dsc_value.unwrap)}'"
+            "'#{escape_quotes(dsc_value.unwrap)}' # PuppetSensitive"
           else
             fail "unsupported type #{dsc_value.class} of value '#{dsc_value}'"
           end

--- a/spec/integration/puppet_x/puppetlabs/powershell_hash_formatter_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/powershell_hash_formatter_spec.rb
@@ -204,7 +204,7 @@ HERE
 'ensure' = 'present';
 'password' = ([PSCustomObject]@{
 'user' = 'jane-doe';
-'password' = 'password'
+'password' = 'password' # PuppetSensitive
 } | new-pscredential);
 'passwordneverexpires' = $false;
 'disabled' = $true

--- a/spec/unit/puppet/provider/powershell_spec.rb
+++ b/spec/unit/puppet/provider/powershell_spec.rb
@@ -27,4 +27,21 @@ describe Puppet::Type.type(:base_dsc_lite).provider(:powershell) do
       expect(subject.class.format_dsc_value("This should show \$foo variable")).to match(/'This should show \$foo variable'/)
     end
   end
+
+  describe "when secrets are present" do
+    it "should unwrap secrets for passing to PowerShell" do
+      sensitive_pass = Puppet::Pops::Types::PSensitiveType::Sensitive.new('password')
+      expect(subject.class.format_dsc_value(sensitive_pass)).to match(/'password' # PuppetSensitive/)
+    end
+    it "should redact secrets for displaying in debug" do
+      # Note that here we're passing a full string as it shows up in the script_content to be executed
+      # This is because we built a matcher to redact the value being passed, but not the key.
+      # This means a redaction of a string not including '= ' before the string value will not redact.
+      # Every secret unwrapped in this module will unwrap as "'secret' # PuppetSensitive" and, currently,
+      # always inside a hash table to be passed along. This means we can (currently) expect the value to
+      # always come after an equals sign.
+      expect(subject.class.redact_content(" 'password' = 'password' # PuppetSensitive\n")).not_to match(/# PuppetSensitive/)
+      expect(subject.class.redact_content(" 'password' = 'password' # PuppetSensitive\n")).to match(/'password' = '\[REDACTED\]'/)
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit the provider would output the full Powershell log to be executed during debug runs. This is to ensure that we can verify exactly what will be executed. However, this also meant that credentials and other secrets could leak into the debug output, and thus also into PuppetDB logs.

This commit modifies the provider, ERB templates, and a helper file to ensure that methods for formatting Puppet data to be PowerShell compliant are able to take a new parameter, `redact`.

Passing this parameter will cause the script builder to redact any sensitive data it is passed. This flag is forwarded along through several helpers. This implementation allows us to reuse the code for interpolating the correct values into the PowerShell script for the actual execution and for the debug messaging.

There is possibly a better implementation for this change.

This commit also includes updated spec and integration tests to verify the behavior when choosing to redact sensitive values.