### PR TITLE
(MODULES-9086) Increase pipe timeout to 180

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changed
+
+- Increase the named pipe timeout to 180 seconds to prevent runs from failing waiting for a pipe to open ([MODULES-9086](https://tickets.puppetlabs.com/browse/MODULES-9086))
+
 ## 2019-04-23 - Supported Release 1.2.1
 
 ### Fixed

--- a/lib/puppet_x/puppetlabs/dsc_lite/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/dsc_lite/powershell_manager.rb
@@ -52,10 +52,10 @@ module PuppetX
         Puppet.debug "#{Time.now} #{cmd} is running as pid: #{@ps_process[:pid]}"
 
         pipe_path = "\\\\.\\pipe\\#{named_pipe_name}"
-        # wait for the pipe server to signal ready, and fail if no response in 10 seconds
+        # wait for the pipe server to signal ready, and fail if no response in 180 seconds
 
-        # wait up to 10 seconds in 0.2 second intervals to be able to open the pipe
-        50.times do
+        # wait up to 180 seconds in 0.2 second intervals to be able to open the pipe
+        900.times do
           begin
             # pipe is opened in binary mode and must always
             @pipe = File.open(pipe_path, 'r+b')


### PR DESCRIPTION
This commit increases the timeout for waiting on the named
pipe to open. This resolves isssues where servers under
heavy load do not open the pipe quickly enough.

NOTE: The code for the PowerShell Code Manager in this
module is out of date with fixes distributed to other
modules and should be updated in a separate ticket.