### PR TITLE
(MODULES-8171) Run fails if paths in $env:lib don't exist

### DIFF
--- a/lib/puppet_x/puppetlabs/dsc_lite/powershell_manager.rb
+++ b/lib/puppet_x/puppetlabs/dsc_lite/powershell_manager.rb
@@ -38,10 +38,24 @@ module PuppetX
         !win32console_enabled?
       end
 
+      def invalid_lib_paths?
+        if ENV["lib"].nil? || ENV["lib"].empty?
+          return false
+        else
+          ENV["lib"].split(";").each do |path|
+            if !File.directory?(path)
+              return true
+            end
+          end
+        end
+      end
+
       def initialize(cmd, debug)
         @usable = true
 
         named_pipe_name = "#{SecureRandom.uuid}PuppetPsHost"
+
+        raise "Bad configuration for ENV['lib']=#{ENV['lib']} - invalid path" if invalid_lib_paths?
 
         ps_args = ['-File', self.class.init_path, "\"#{named_pipe_name}\""]
         ps_args << '"-EmitDebugOutput"' if debug


### PR DESCRIPTION
  Prior to this commit, Puppet fails while compiling C# code within init_ps.ps1 with a cryptic no implicit conversion of nil into String message.

  This commit checks that the LIB environment variable contains invalid paths and fails with a useful error message.