### PR TITLE
(MODULES-7762) State Exact PS Version Requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- Added a note to the readme specifying the exact PowerShell version required for the module to function ([MODULES-7762](https://tickets.puppetlabs.com/browse/MODULES-7762))
+
 ### Changed
 
 - Increase the named pipe timeout to 180 seconds to prevent runs from failing waiting for a pipe to open ([MODULES-9086](https://tickets.puppetlabs.com/browse/MODULES-9086))

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The Puppet dsc_lite module allows you to manage target nodes using Windows Power
 
 At least PowerShell 5.0, which is included in [Windows Management Framework 5.0][wmf-5.0].
 
+*Note: PowerShell version as obtained from `$PSVersionTable` must be 5.0.10586.117 or greater.*
+
 ## Setup
 
 ~~~bash


### PR DESCRIPTION
Add a note in the readme that specifies the exact PowerShell version
required to make the module function. While 99% of customers will get
the correct version if they install WMF 5, there was a version released
that will not satisfy this requirement.