### PR TITLE
(FM-8391) Update README per team practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,11 +377,20 @@ By using the debug logging of a Puppet run, you can troubleshoot the application
 
 ## Development
 
-Puppet modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can’t access the huge number of platforms and myriad of hardware, software, and deployment configurations that Puppet is intended to serve.
+Acceptance tests for this module leverage [puppet_litmus](https://github.com/puppetlabs/puppet_litmus).
+To run the acceptance tests follow the instructions [here](https://github.com/puppetlabs/puppet_litmus/wiki/Tutorial:-use-Litmus-to-execute-acceptance-tests-with-a-sample-module-(MoTD)#install-the-necessary-gems-for-the-module).
+You can also find a tutorial and walkthrough of using Litmus and the PDK on [YouTube](https://www.youtube.com/watch?v=FYfR7ZEGHoE).
 
-If you would like to contribute to this module, please follow the guidelines in [CONTRIBUTING.md](https://github.com/puppetlabs/puppetlabs-dsc_lite/blob/master/CONTRIBUTING.md). 
+If you run into an issue with this module, or if you would like to request a feature, please [file a ticket](https://tickets.puppetlabs.com/browse/MODULES/).
+Every Monday the Puppet IA Content Team has [office hours](https://puppet.com/community/office-hours) in the [Puppet Community Slack](http://slack.puppet.com/), alternating between an EMEA friendly time (1300 UTC) and an Americas friendly time (0900 Pacific, 1700 UTC).
 
-For further information, see our [module contribution guide](https://puppet.com/docs/puppet/latest/contributing.html).
+If you have problems getting this module up and running, please [contact Support](http://puppetlabs.com/services/customer-support).
+
+If you submit a change to this module, be sure to regenerate the reference documentation as follows:
+
+```bash
+puppet strings generate --format markdown --out REFERENCE.md
+```
 
 ### Contributors
 


### PR DESCRIPTION
This commit updates the readme to remove the language marking litmus
as an experimental tool as well as clarifying the instructions for
running acceptance tests and noting the schedule for the IA Content
office hours.