### PR TITLE
(MAINT) Safeguard loading ruby-pwsh

### DIFF
--- a/lib/puppet/provider/base_dsc_lite/powershell.rb
+++ b/lib/puppet/provider/base_dsc_lite/powershell.rb
@@ -1,9 +1,9 @@
 require 'pathname'
 require 'json'
-require 'ruby-pwsh'
 require_relative '../../../puppet_x/puppetlabs/dsc_lite/powershell_hash_formatter'
 
 Puppet::Type.type(:base_dsc_lite).provide(:powershell) do
+  confine feature: :pwshlib
   confine operatingsystem: :windows
   defaultfor operatingsystem: :windows
 


### PR DESCRIPTION
This commit replaces the requires statement in the provider
with a confine to the pwshlib feature provided in the dependent
module to prevent exploding puppet runs on provider load.