### PR TITLE
(MODULES-10471) Allow namevar to have special chars

### DIFF
--- a/lib/puppet/type/dsc.rb
+++ b/lib/puppet/type/dsc.rb
@@ -54,7 +54,7 @@ Puppet::Type.newtype(:dsc) do
       if value.nil? || value.empty?
         raise ArgumentError, "A non-empty #{name} must be specified."
       end
-      raise("#{value} is not a valid #{name}") unless value =~ %r{^[a-zA-Z0-9\.\-\_\'\s]+$}
+      raise("#{value} is not a valid #{name}") unless value.is_a? ::String
     end
   end
 

--- a/spec/unit/puppet/type/dsc_spec.rb
+++ b/spec/unit/puppet/type/dsc_spec.rb
@@ -52,7 +52,7 @@ describe Puppet::Type.type(:dsc) do
     it 'does not allow nil' do
       expect {
         resource[:resource_name] = nil
-      }.to raise_error(Puppet::Error, %r{Got nil value for})
+      }.to raise_error(Puppet::Error, %r{Got nil value for resource_name})
     end
 
     it 'does not allow empty' do

--- a/spec/unit/puppet/type/dsc_spec.rb
+++ b/spec/unit/puppet/type/dsc_spec.rb
@@ -39,15 +39,9 @@ describe Puppet::Type.type(:dsc) do
       }.to raise_error(Puppet::ResourceError, %r{A non-empty name must})
     end
 
-    ['value', 'value with spaces', 'UPPER CASE', '0123456789_-', 'With.Period'].each do |value|
+    ['value', 'value with spaces', 'UPPER CASE', '0123456789_-', 'With.Period', 'With=Special,Chars'].each do |value|
       it "should accept '#{value}'" do
         expect { resource[:name] = value }.not_to raise_error
-      end
-    end
-
-    ['*', '()', '[]', '!@'].each do |value|
-      it "should reject '#{value}'" do
-        expect { resource[:name] = value }.to raise_error(Puppet::ResourceError, %r{is not a valid name})
       end
     end
   end
@@ -57,25 +51,19 @@ describe Puppet::Type.type(:dsc) do
 
     it 'does not allow nil' do
       expect {
-        resource[:name] = nil
-      }.to raise_error(Puppet::Error, %r{Got nil value for name})
+        resource[:resource_name] = nil
+      }.to raise_error(Puppet::Error, %r{Got nil value for})
     end
 
     it 'does not allow empty' do
       expect {
-        resource[:name] = ''
-      }.to raise_error(Puppet::ResourceError, %r{A non-empty name must})
+        resource[:resource_name] = ''
+      }.to raise_error(Puppet::ResourceError, %r{A non-empty resource_name must})
     end
 
     ['value', 'value with spaces', 'UPPER CASE', '0123456789_-', 'With.Period'].each do |value|
       it "should accept '#{value}'" do
-        expect { resource[:name] = value }.not_to raise_error
-      end
-    end
-
-    ['*', '()', '[]', '!@'].each do |value|
-      it "should reject '#{value}'" do
-        expect { resource[:name] = value }.to raise_error(Puppet::ResourceError, %r{is not a valid name})
+        expect { resource[:resource_name] = value }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
Prior to this PR, the namevar in the dsc type allowed a subset of
characters. This was not a functional limit and did not need to be in
place. This PR removes this restriction and ensure the name is a
string.

 This PR also fixes the spec tests for the `resource_name` as
they were only testing the `name` parameter. This just updates it to test the `resource_name` and removes the spec tests for the special character limitations.