### PR TITLE
Fix ERB.new depracation notices

### DIFF
--- a/lib/puppet/provider/base_dsc_lite/powershell.rb
+++ b/lib/puppet/provider/base_dsc_lite/powershell.rb
@@ -150,7 +150,7 @@ Puppet::Type.type(:base_dsc_lite).provide(:powershell) do
     @param_hash = resource
     template_name = resource.generic_dsc ? '/invoke_generic_dsc_resource.ps1.erb' : '/invoke_dsc_resource.ps1.erb'
     file = File.new(template_path + template_name, encoding: Encoding::UTF_8)
-    template = ERB.new(file.read, nil, '-')
+    template = ERB.new(file.read, trim_mode: '-')
     template.result(binding)
   end
 end


### PR DESCRIPTION
This fixes these 2 deprecation warnings which appear on each puppet-run:
```
Info: Applying configuration version '1711367415'
C:/ProgramData/PuppetLabs/puppet/var/lib/puppet/provider/base_dsc_lite/powershell.rb:153: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
C:/ProgramData/PuppetLabs/puppet/var/lib/puppet/provider/base_dsc_lite/powershell.rb:153: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```

Could you please merge it and publish a new version on the forge?