### PR TITLE
(CAT-1927) - Remove Windows 7, 8.x and 2008 R2 Support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,6 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "7",
         "8",
         "8.1",
         "10",

--- a/metadata.json
+++ b/metadata.json
@@ -21,8 +21,6 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "8",
-        "8.1",
         "10",
         "2008 R2",
         "2012 R2",

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,6 @@
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
         "10",
-        "2008 R2",
         "2012 R2",
         "2012",
         "2016",


### PR DESCRIPTION
Remove Windows 7, 8.x and 2008 R2 Support, these platforms are no longer supported by puppet agent and therefore cannot be supported for use with this module.