### PR TITLE
(Bug) - Fix timeout matcher

### DIFF
--- a/spec/acceptance/dsc_type/psdesiredstateconfiguration_spec.rb
+++ b/spec/acceptance/dsc_type/psdesiredstateconfiguration_spec.rb
@@ -64,7 +64,7 @@ describe 'PSDesiredStateConfiguration' do
   context 'times out when execution time is greater than dsc_timeout' do
     it 'applies manifest' do
       apply_manifest(dsc_timeout_manifest, expect_failures: true) do |result|
-        expect(result.stderr).to match(%r{The DSC Resource did not respond within the timeout limit of 1000 milliseconds})
+        expect(result.stderr).to match(%r{Catastrophic failure: PowerShell module timeout \(1000 ms\) exceeded while executing})
       end
     end
   end


### PR DESCRIPTION
Ths commit fixes the timeout matcher to more accurately match a legitimate dsc timeout. Before, if output was nil for any other reason dsc_lite would assume timeout which is not strictly correct. There is a specific error message returned on dsc timeout which we should strive to match instead.

Additionally, moved the logic to only execute for nodes with windows powershell support as we can only pass a timeout to powershell on these nodes, and use the default error output from powershell as it is more concise and does a better job of conveying the message.