### PR TITLE
(MAINT) Addresing pwshlib dependency error

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/pwshlib",
-      "version_requirement": ">= 0.4.0 < 2.0.0"
+      "version_requirement": ">= 0.4.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This commit addresses an issue where the module expectes a pwshlib dependency lower than 2.0.0 but brings in exactly 2.0.0.