### PR TITLE
(maint) Increase ruby-pwsh boundaries for unit tests to pass

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/pwshlib",
-      "version_requirement": ">= 0.4.0 < 2.0.0"
+      "version_requirement": ">= 0.4.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Prior to this commit unit tests were passing on the dependency checker. 

This issue resolves the failure in the unit tests. 