### PR TITLE
(CAT-2632) Implement initial safe fork CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,33 @@
-name: "ci"
+name: "CI"
 
 on:
   pull_request:
     branches:
       - "main"
+  pull_request_target:
+    types: [labeled, reopened]
+    branches:
+      - "main"
   workflow_dispatch:
-    
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Spec:
-    uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@main"
-    secrets: "inherit"
+    if: github.event_name != 'pull_request_target'
+    uses: "puppetlabs/cat-github-actions/.github/workflows/module_ci.yml@CAT-2632-enable_safe_fork_pr_ci"
 
   Acceptance:
-    needs: Spec
-    uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true && contains(github.event.pull_request.labels.*.name, 'allowed-for-ci'))
+    uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@CAT-2632-enable_safe_fork_pr_ci"
     with:
       flags: "--latest-agent"
     secrets: "inherit"

--- a/.github/workflows/fork_ci_label_guard.yml
+++ b/.github/workflows/fork_ci_label_guard.yml
@@ -1,0 +1,12 @@
+name: "Fork CI Label Guard"
+
+on:
+  pull_request_target:
+    types: [synchronize, closed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  strip:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/fork_ci_label_guard.yml@CAT-2632-enable_safe_fork_pr_ci"

--- a/Gemfile
+++ b/Gemfile
@@ -69,8 +69,7 @@ group :development, :release_prep do
   gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
+  gem 'puppet_litmus', '~> 2.5',   require: false
   gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',     require: false
 end


### PR DESCRIPTION
Enable safe fork-PR CI against private puppetcore using the two-track pattern, and consolidate puppet_litmus to a single gem version.