### PR TITLE
(CAT-2632) Fork CI test

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,3 +442,5 @@ There are several books available as well. Here are some selected books for refe
 * Copyright (c) 2014 Marc Sutter, original author
 * Copyright (c) 2015 - Present Puppet Inc
 * License: [Apache License, Version 2.0](https://github.com/puppetlabs/puppetlabs-dsc/blob/master/LICENSE)
+
+<!-- CI trigger: fork PR test (CAT-2632) -->


### PR DESCRIPTION
Clean fork PR (from `LukasAud/puppetlabs-dsc_lite`) to exercise the safe fork-PR CI now that the workflows are on `main`.

Contains only a trivial README change to trigger CI — no workflow/source changes.

Expected:
- `Spec` runs on the fork `pull_request` (no secrets).
- `Acceptance` stays skipped until a CODEOWNER applies the `allowed-for-ci` label → fires `pull_request_target`.
- Pushing a new commit triggers the Fork CI Label Guard to strip the label.

Do not merge — testing only.