### PR TITLE
(CAT-2632) Non-fork CI backwards-compat test

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,3 +442,5 @@ There are several books available as well. Here are some selected books for refe
 * Copyright (c) 2014 Marc Sutter, original author
 * Copyright (c) 2015 - Present Puppet Inc
 * License: [Apache License, Version 2.0](https://github.com/puppetlabs/puppetlabs-dsc/blob/master/LICENSE)
+
+<!-- CI trigger: non-fork backwards-compat test (CAT-2632) -->


### PR DESCRIPTION
Regular (non-fork) PR from the canonical repo to verify backwards compatibility of the new CI after the safe fork-PR changes landed on `main`.

Contains only a trivial README change to trigger CI — no workflow/source changes.

Expected:
- `Spec` runs via `pull_request`.
- `Acceptance` runs directly (no label required), because `github.event.pull_request.head.repo.fork == false`.
- The Fork CI Label Guard / `pull_request_target` path is not involved.

Do not merge — testing only.